### PR TITLE
Zk testnet USDC via paymaster

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -1,4 +1,4 @@
- {
+{
   "name": "@scaffold-eth/react-app",
   "version": "1.0.0",
   "homepage": ".",
@@ -16,9 +16,9 @@
     "@testing-library/user-event": "^12.1.8",
     "@uniswap/sdk": "^3.0.3",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
+    "@walletconnect/utils": "^2.7.2",
     "@walletconnect/web3-provider": "^1.6.5",
     "@walletconnect/web3wallet": "^1.7.0",
-    "@walletconnect/utils": "^2.7.2",
     "antd": "^4.7.0",
     "apollo-boost": "^0.4.9",
     "apollo-client": "^2.6.10",
@@ -45,7 +45,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
     "typescript": "^4.9.4",
-    "web3modal": "^1.9.11"
+    "web3modal": "^1.9.11",
+    "zksync-web3": "^0.14.3"
   },
   "devDependencies": {
     "@testing-library/dom": "^6.12.2",

--- a/packages/react-app/src/components/TransactionHistory.jsx
+++ b/packages/react-app/src/components/TransactionHistory.jsx
@@ -10,7 +10,13 @@ export default function TransactionHistory({ transactionResponsesArray, transact
   const transactionList = (
     <List
       itemLayout="vertical"
-      dataSource={transactionResponsesArray.sort((a, b) => b.nonce - a.nonce)}
+      dataSource={
+        transactionResponsesArray.sort(
+            (a, b) => {
+              return new Date(b.date) - new Date(a.date);
+            }
+          )
+      }
       renderItem={(transactionResponse) => (
         <List.Item>
           <List.Item.Meta

--- a/packages/react-app/src/components/TransactionResponseDisplay.jsx
+++ b/packages/react-app/src/components/TransactionResponseDisplay.jsx
@@ -185,7 +185,7 @@ export default function TransactionResponseDisplay({transactionResponse, transac
 
   return  (
     <div style={{ padding: 16 }}>
-      {(transactionResponse.hash && (transactionResponse.nonce || transactionResponse?.nonce == 0)) && <a style={{ color:'rgb(24, 144, 255)' }} href={blockExplorer + "tx/" + transactionResponse.hash}>{transactionResponse.nonce}</a>}
+      {(transactionResponse.hash && (transactionResponse.nonce || transactionResponse?.nonce == 0)) && <a style={{ color:'rgb(24, 144, 255)' }} href={blockExplorer + "tx/" + transactionResponse.hash}>{transactionResponse?.origin ? "Gasless tx " + transactionResponse.nonce : transactionResponse.nonce}</a>}
       {!isCancelTransaction(transactionResponse) ?
         <>
           <div style={{ position:"relative",left:-120, top:-30 }}>
@@ -234,7 +234,7 @@ export default function TransactionResponseDisplay({transactionResponse, transac
               size="large"
               shape="round"
               loading={loadingCancel}
-              disabled={loadingSpeedUp || loadingCancel}
+              disabled={loadingSpeedUp || loadingCancel || transactionResponse.origin}
              >
               Cancel
              </Button>
@@ -248,7 +248,7 @@ export default function TransactionResponseDisplay({transactionResponse, transac
               size="large"
               shape="round"
               loading={loadingSpeedUp}
-              disabled={loadingSpeedUp || loadingCancel}
+              disabled={loadingSpeedUp || loadingCancel || transactionResponse.origin}
              >
               {!isCancelTransaction(transactionResponse) ? <> Speed Up 10% </> : <> Speed Up This Cancellation 10% </>}
              </Button>

--- a/packages/react-app/src/components/TransactionResponses.jsx
+++ b/packages/react-app/src/components/TransactionResponses.jsx
@@ -21,7 +21,7 @@ export default function TransactionResponses({provider, signer, injectedProvider
   const filterResponsesAddressAndChainId = (transactionResponsesArray) => {
     return transactionResponsesArray.filter(
       transactionResponse => {
-        return (transactionResponse.from == address) && (transactionResponse.chainId == chainId);
+        return ((transactionResponse.from == address) || (transactionResponse?.origin == address)) && (transactionResponse.chainId == chainId);
       })
   }
 

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -506,6 +506,18 @@ export const NETWORKS = {
     chainId: 280,
     rpcUrl: "https://testnet.era.zksync.dev",
     blockExplorer: "https://goerli.explorer.zksync.io/",
+    erc20Tokens: [
+      {
+        name: "USDC",
+        address: "0x0faF6df7054946141266420b43783387A78d82A9",
+        decimals: 6,
+        imgSrc: "/USDC.png"
+      }
+    ],
+    nativeToken: {
+      name:"ETH",
+      imgSrc:"/ETH.png"
+    }
   },
   canto: {
     name: "canto",

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -11,6 +11,8 @@ export const BLOCKNATIVE_DAPPID = "0b58206a-f3c0-4701-a62f-73c7243e8c77";
 
 export const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 
+export const ZK_TESTNET_USDC_ADDRESS = "0x0faF6df7054946141266420b43783387A78d82A9";
+
 export const DAI_ABI = [
   {
     inputs: [{ internalType: "uint256", name: "chainId_", type: "uint256" }],
@@ -509,7 +511,7 @@ export const NETWORKS = {
     erc20Tokens: [
       {
         name: "USDC",
-        address: "0x0faF6df7054946141266420b43783387A78d82A9",
+        address: ZK_TESTNET_USDC_ADDRESS,
         decimals: 6,
         imgSrc: "/USDC.png"
       }

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -12,6 +12,7 @@ export const BLOCKNATIVE_DAPPID = "0b58206a-f3c0-4701-a62f-73c7243e8c77";
 export const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 
 export const ZK_TESTNET_USDC_ADDRESS = "0x0faF6df7054946141266420b43783387A78d82A9";
+export const POLYGON_USDC_ADDRESS = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 
 export const DAI_ABI = [
   {
@@ -451,7 +452,7 @@ export const NETWORKS = {
     erc20Tokens: [
       {
         name: "USDC",
-        address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        address: POLYGON_USDC_ADDRESS,
         decimals: 6,
         imgSrc: "/USDC.png"
       },

--- a/packages/react-app/src/helpers/EIP1559Helper.js
+++ b/packages/react-app/src/helpers/EIP1559Helper.js
@@ -61,7 +61,7 @@ export const sendTransaction =  (txParams, signer, injectedProvider) => {
 		return sendTransactionMainnet(txParams);
 	}
 	else if (chainId == NETWORKS.polygon.chainId) {
-		return sendTransactionPolygon(txParams);
+		return sendTransactionPolygon(txParams, signer);
 	}
 }
 
@@ -87,7 +87,7 @@ const sendTransactionMainnet = (txParams) => {
 
 // Ethers cannot figure out maxFeePerGas and maxPriorityFeePerGas properly
 // https://github.com/ethers-io/ethers.js/issues/2828#issuecomment-1283014250
-const sendTransactionPolygon = async (txParams) => {
+const sendTransactionPolygon = async (txParams, signer) => {
 	let gasData = (await axios.get(POLYGON_GAS_API_URL)).data;
 
 		/* Example response
@@ -116,7 +116,7 @@ const sendTransactionPolygon = async (txParams) => {
 	txParams.maxPriorityFeePerGas = getHexStringFromGasNumber(maxPriorityFee);
 	console.log("updated txParams", txParams);
 
-	const ethersWallet = getEthersWallet(txParams);
+	const ethersWallet = signer ? signer : getEthersWallet(txParams);
 	return ethersWallet.sendTransaction(txParams);
 }
 

--- a/packages/react-app/src/helpers/PolygonTransferWithAuthorizationHelper.js
+++ b/packages/react-app/src/helpers/PolygonTransferWithAuthorizationHelper.js
@@ -1,0 +1,98 @@
+import { getEthersWallet, sendTransaction } from "./EIP1559Helper";
+import { NETWORKS, POLYGON_USDC_ADDRESS } from "../constants";
+
+const { ethers, BigNumber } = require("ethers");
+
+const RELAYER_PK = process.env.REACT_APP_RELAYER_PK;
+
+const ABI = [
+    "function transferWithAuthorization (address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s)"
+];
+
+export const transferWithAuthorization = async (to, value) => {
+  const validAfter  = "0x0000000000000000000000000000000000000000000000000000000000000001"; // signature valid from the beginning
+
+  const provider = new ethers.providers.JsonRpcProvider(NETWORKS.polygon.rpcUrl);
+  const timestamp = (await provider.getBlock()).timestamp + 60;                             // signature valid till a minute
+  const validBefore = ethers.utils.hexZeroPad(BigNumber.from(timestamp).toHexString(), 32);
+
+  const nonce = ethers.utils.hexlify(ethers.utils.randomBytes(32));                         // eip-3009 uses Unique Random Nonces
+
+  const txParams = {};
+  txParams.chainId = NETWORKS.polygon.chainId;
+
+  const signerWallet = getEthersWallet(txParams);
+  const transferWithAuthorizationSignature = await getTransferWithAuthorizationSignature(signerWallet, to, value, validAfter, validBefore, nonce);
+
+  const contract = new ethers.Contract(POLYGON_USDC_ADDRESS, ABI, provider);
+
+  const populatedTransaction =
+    await contract.populateTransaction.transferWithAuthorization(
+        signerWallet.address, to, value, validAfter, validBefore, nonce, transferWithAuthorizationSignature.v, transferWithAuthorizationSignature.r, transferWithAuthorizationSignature.s);
+
+  txParams.from = populatedTransaction.from;
+  txParams.to = populatedTransaction.to;
+  txParams.data = populatedTransaction.data;
+
+  const relayerWallet = new ethers.Wallet(RELAYER_PK, provider);
+
+  const result = await sendTransaction(txParams, relayerWallet);
+
+  result.origin = signerWallet.address;
+
+  return result;
+}
+
+const getTransferWithAuthorizationSignature = async (signer, to, value, validAfter, validBefore, nonce) => {
+  const name = "USD Coin (PoS)";
+  const version = "1";
+  const verifyingContract = POLYGON_USDC_ADDRESS;
+  const salt = ethers.utils.hexZeroPad(ethers.utils.hexlify(NETWORKS.polygon.chainId), 32);
+
+  return ethers.utils.splitSignature(
+    await signer._signTypedData(
+      {
+        name,
+        version,
+        verifyingContract,
+        salt
+      },
+      {
+        TransferWithAuthorization: [
+          {
+            name: "from",
+            type: "address",
+          },
+          {
+            name: "to",
+            type: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+          },
+          {
+            name: "validAfter",
+            type: "uint256",
+          },
+          {
+            name: "validBefore",
+            type: "uint256",
+          },
+          {
+            name: "nonce",
+            type: "bytes32",
+          }
+        ],
+      },
+      {
+        from: signer.address,
+        to,
+        value,
+        validAfter,
+        validBefore,
+        nonce,
+      }
+    )
+  )
+}

--- a/packages/react-app/src/helpers/TransactionManager.js
+++ b/packages/react-app/src/helpers/TransactionManager.js
@@ -77,6 +77,10 @@ export class TransactionManager {
 			newTransactionResponse.erc20 = transactionResponse.erc20;
 		}
 
+		if (newTransactionResponse && transactionResponse?.origin) {
+			newTransactionResponse.origin = transactionResponse.origin;
+		}
+
 		this.setTransactionResponse(newTransactionResponse ? newTransactionResponse : transactionResponse);
 	}
 

--- a/packages/react-app/src/helpers/Transactor.js
+++ b/packages/react-app/src/helpers/Transactor.js
@@ -6,8 +6,9 @@ import { BLOCKNATIVE_DAPPID } from "../constants";
 import { TransactionManager } from "./TransactionManager";
 import { sendTransaction } from "./EIP1559Helper";
 import { getTransferTxParams } from "./ERC20Helper";
+import { transferWithAuthorization } from "./PolygonTransferWithAuthorizationHelper";
 import { transferViaPaymaster } from "./zkSyncTestnetHelper";
-import { ZK_TESTNET_USDC_ADDRESS } from "../constants";
+import { ZK_TESTNET_USDC_ADDRESS, POLYGON_USDC_ADDRESS } from "../constants";
 
 // this should probably just be renamed to "notifier"
 // it is basically just a wrapper around BlockNative's wonderful Notify.js
@@ -54,6 +55,9 @@ export default function Transactor(provider, gasPrice, etherscan, injectedProvid
               const zkResult = await transferViaPaymaster(erc20.to, erc20.amount * 1000000);
               console.log("zkResult", zkResult);
               result = await provider.getTransaction(zkResult.transactionHash);
+            }
+            else if (erc20?.token?.address == POLYGON_USDC_ADDRESS) {
+              result = await transferWithAuthorization(erc20.to, erc20.amount * 1000000)
             }
             else {
               const transferTxParams = await getTransferTxParams(erc20.token, erc20.to, erc20.amount);

--- a/packages/react-app/src/helpers/zkSyncTestnetHelper.js
+++ b/packages/react-app/src/helpers/zkSyncTestnetHelper.js
@@ -1,0 +1,36 @@
+import { createEthersWallet } from "./EIP1559Helper";
+import { ZK_TESTNET_USDC_ADDRESS } from "../constants";
+
+const { Provider, Contract, Wallet, utils } =  require("zksync-web3");
+
+const ERC20ABI = '[ { "anonymous": false, "inputs": [ { "indexed": true, "internalType": "address", "name": "owner", "type": "address" }, { "indexed": true, "internalType": "address", "name": "spender", "type": "address" }, { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" } ], "name": "Approval", "type": "event" }, { "anonymous": false, "inputs": [ { "indexed": true, "internalType": "address", "name": "from", "type": "address" }, { "indexed": true, "internalType": "address", "name": "to", "type": "address" }, { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" } ], "name": "Transfer", "type": "event" }, { "inputs": [ { "internalType": "address", "name": "owner", "type": "address" }, { "internalType": "address", "name": "spender", "type": "address" } ], "name": "allowance", "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ], "stateMutability": "view", "type": "function" }, { "inputs": [ { "internalType": "address", "name": "spender", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" } ], "name": "approve", "outputs": [ { "internalType": "bool", "name": "", "type": "bool" } ], "stateMutability": "nonpayable", "type": "function" }, { "inputs": [ { "internalType": "address", "name": "account", "type": "address" } ], "name": "balanceOf", "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ], "stateMutability": "view", "type": "function" }, { "inputs": [], "name": "decimals", "outputs": [ { "internalType": "uint8", "name": "", "type": "uint8" } ], "stateMutability": "view", "type": "function" }, { "inputs": [], "name": "name", "outputs": [ { "internalType": "string", "name": "", "type": "string" } ], "stateMutability": "view", "type": "function" }, { "inputs": [], "name": "symbol", "outputs": [ { "internalType": "string", "name": "", "type": "string" } ], "stateMutability": "view", "type": "function" }, { "inputs": [], "name": "totalSupply", "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ], "stateMutability": "view", "type": "function" }, { "inputs": [ { "internalType": "address", "name": "recipient", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" } ], "name": "transfer", "outputs": [], "stateMutability": "nonpayable", "type": "function" }, { "inputs": [ { "internalType": "address", "name": "sender", "type": "address" }, { "internalType": "address", "name": "recipient", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" } ], "name": "transferFrom", "outputs": [], "stateMutability": "nonpayable", "type": "function" } ]';
+
+const PAYMASTER_ADDRESS = "0xDB4FB4fC0378448f98Ae9967F2081EE899159c20";
+
+export const transferViaPaymaster = async (to, amount) => {
+	let zkWallet = new Wallet(createEthersWallet());
+	const zkProvider = new Provider("https://testnet.era.zksync.dev");
+	zkWallet = zkWallet.connect(zkProvider);
+
+	const tokenUSDC = new Contract(ZK_TESTNET_USDC_ADDRESS, ERC20ABI, zkWallet);
+
+	const paymasterParams = utils.getPaymasterParams(PAYMASTER_ADDRESS, {
+        type: "ApprovalBased",
+        token: ZK_TESTNET_USDC_ADDRESS,
+        minimalAllowance: 100000,
+        innerInput: new Uint8Array(),
+    });
+
+    const result = await (
+        await tokenUSDC.transfer(to, amount, {
+            // paymaster info
+            customData: {
+                paymasterParams: paymasterParams,
+                gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+            },
+        })
+    ).wait();
+
+
+	return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22080,3 +22080,8 @@ zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zksync-web3@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
+  integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==


### PR DESCRIPTION
**EDIT**: I pushed another commit for "gasless" USDC transfer on Polygon
https://uptight-motion.surge.sh/

On **Polygon**, eip-3009 is used, to sign a [_transferWithAuthorization](https://github.com/centrehq/centre-tokens/blob/0d3cab14ebd133a83fc834dbd48d0468bdf0b391/contracts/v2/EIP3009.sol#L89) message, then the signature is executed with a [relayer account](https://polygonscan.com/address/0x7f6417a33c78041c0b9ff68a68421f873195e42e).
Polygon is so cheap that 1$ worth of Matic should cover for about 100 transations.

https://github.com/scaffold-eth/punk-wallet/assets/1397179/b405f892-ed4c-4e16-9beb-886d899bb482




On **zkSyncTestnet** the tx fee is covered with a paymaster.
This is a zkSyncTestnet POC how "gasless" USDC transfer could work.
The [paymaster](https://github.com/scaffold-eth/scaffold-eth-2/commit/56dbb206b5f5c6b3fc1196353eba55678abee740) requires a hardcoded **0.1 USDC** to make the transfer.

Here is a test private key for a USDC holder:
0xbc243a19ccf5f502bbffde4dd02cebddc0b19b0f240d1f5fb5f015ee0db030c5

https://github.com/scaffold-eth/punk-wallet/assets/1397179/f6757497-af5c-4d03-b530-9fcc1d92eac9


