### PR TITLE
Gasless DAI and USDT transfer on Polygon, using NativeMetaTransactions.

### DIFF
--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -460,13 +460,21 @@ export const NETWORKS = {
         name: "USDT",
         address: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
         decimals: 6,
-        imgSrc: "/USDT.png"
+        imgSrc: "/USDT.png",
+        NativeMetaTransaction: {
+          name: "(PoS) Tether USD",
+          ERC712_VERSION: "1"
+        }
       },
       {
         name: "DAI",
         address: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
         decimals: 18,
-        imgSrc: "/DAI.png"
+        imgSrc: "/DAI.png",
+        NativeMetaTransaction: {
+          name: "(PoS) Dai Stablecoin",
+          ERC712_VERSION: "1"
+        }
       },
     ],
     nativeToken: {

--- a/packages/react-app/src/helpers/PolygonNativeMetaTransaction.js
+++ b/packages/react-app/src/helpers/PolygonNativeMetaTransaction.js
@@ -1,0 +1,103 @@
+// Tokens on Polygon implement Meta Transactions
+// https://github.com/maticnetwork/pos-portal/blob/ece4e54546a4e075f3a03b2699bc6bd92a5bc065/contracts/common/NativeMetaTransaction.sol
+// https://wiki.polygon.technology/docs/pos/design/transactions/meta-transactions/meta-transactions
+
+// Instead of calling the transfer function on the token contract and pay for the transaction fee,
+// we can sign the transfer message, and call the executeMetaTransaction function with the signature,
+// from a different "relayer account", who has MATIC to pay for the transaction.
+
+import { createEthersWallet } from "./EIP1559Helper";
+import { sendTransactionViaRelayerAccount } from "./PolygonRelayerAccountHelper";
+import { NETWORKS } from "../constants";
+
+import { getTransferTxParams } from "./ERC20Helper";
+
+const { ethers } = require("ethers");
+
+const ABI = [
+    "function getNonce(address user) view returns (uint256)",
+    "function executeMetaTransaction(address userAddress,bytes calldata functionSignature, bytes32 sigR, bytes32 sigS, uint8 sigV) payable returns (bytes)"
+];
+
+const getExecuteMetaTransactionSignature = async (token, signer, nonce, functionSignature) => {
+  const name = token.NativeMetaTransaction.name;
+  const version = token.NativeMetaTransaction.ERC712_VERSION;
+  const verifyingContract = token.address;
+  const salt = ethers.utils.hexZeroPad(ethers.utils.hexlify(NETWORKS.polygon.chainId), 32);
+
+  return ethers.utils.splitSignature(
+    await signer._signTypedData(
+      {
+        name,
+        version,
+        verifyingContract,
+        salt
+      },
+      {
+        MetaTransaction: [
+          {
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            name: "from",
+            type: "address",
+          },
+          {
+            name: "functionSignature",
+            type: "bytes",
+          }
+        ],
+      },
+      {
+        nonce,
+        from: signer.address,
+        functionSignature
+      }
+    )
+  )
+}
+
+export const transferNativeMetaTransaction = async (token, to, amount) => {
+	console.log("Gasless token transfer: ", token, to, amount);
+
+  const transferTxParams = await getTransferTxParams(token, to, amount);
+  console.log("transferTxParams", transferTxParams);
+
+	const transferData = transferTxParams.data;
+	console.log("transferData", transferData);
+
+	const signerWallet = createEthersWallet();
+
+	const provider = new ethers.providers.JsonRpcProvider(NETWORKS.polygon.rpcUrl);
+	const contract = new ethers.Contract(token.address, ABI, provider);
+
+	const signerNonce = await contract.getNonce(signerWallet.address);
+	console.log("signerNonce", signerNonce);
+
+	const executeMetaTransactionSignature =
+		await getExecuteMetaTransactionSignature(token, signerWallet, signerNonce, transferData);
+
+	console.log("executeMetaTransactionSignature", executeMetaTransactionSignature);
+
+	const txParams =
+		await contract.populateTransaction.executeMetaTransaction(
+			signerWallet.address, transferData, executeMetaTransactionSignature.r, executeMetaTransactionSignature.s, executeMetaTransactionSignature.v);
+
+	console.log("txParams", JSON.parse(JSON.stringify(txParams)));
+
+	txParams.chainId = NETWORKS.polygon.chainId;
+
+  return sendTransactionViaRelayerAccount(txParams, signerWallet.address, provider);
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/packages/react-app/src/helpers/PolygonRelayerAccountHelper.js
+++ b/packages/react-app/src/helpers/PolygonRelayerAccountHelper.js
@@ -1,0 +1,15 @@
+import { sendTransaction } from "./EIP1559Helper";
+
+const { ethers } = require("ethers");
+
+const RELAYER_PK = process.env.REACT_APP_RELAYER_PK;
+
+export const sendTransactionViaRelayerAccount = async (txParams, origin, provider) => {
+	const relayerWallet = new ethers.Wallet(RELAYER_PK, provider);
+
+	const result = await sendTransaction(txParams, relayerWallet);
+
+	result.origin = origin;
+
+	return result;
+}

--- a/packages/react-app/src/helpers/Transactor.js
+++ b/packages/react-app/src/helpers/Transactor.js
@@ -7,6 +7,7 @@ import { TransactionManager } from "./TransactionManager";
 import { sendTransaction } from "./EIP1559Helper";
 import { getTransferTxParams } from "./ERC20Helper";
 import { transferWithAuthorization } from "./PolygonTransferWithAuthorizationHelper";
+import { transferNativeMetaTransaction } from "./PolygonNativeMetaTransaction";
 import { transferViaPaymaster } from "./zkSyncTestnetHelper";
 import { ZK_TESTNET_USDC_ADDRESS, POLYGON_USDC_ADDRESS } from "../constants";
 
@@ -58,6 +59,9 @@ export default function Transactor(provider, gasPrice, etherscan, injectedProvid
             }
             else if (erc20?.token?.address == POLYGON_USDC_ADDRESS) {
               result = await transferWithAuthorization(erc20.to, erc20.amount * 1000000)
+            }
+            else if (erc20?.token?.NativeMetaTransaction) {
+              result = await transferNativeMetaTransaction(erc20.token, erc20.to, erc20.amount);
             }
             else {
               const transferTxParams = await getTransferTxParams(erc20.token, erc20.to, erc20.amount);


### PR DESCRIPTION
https://dynamic-number.surge.sh/

Tokens on Polygon implement [Meta Transactions](https://github.com/maticnetwork/pos-portal/blob/ece4e54546a4e075f3a03b2699bc6bd92a5bc065/contracts/common/NativeMetaTransaction.sol), with which we can send DAI and USDT around, and pay for the tx fee with the "relayer account".