### PR TITLE
Extend method list with eth_signTypedData_v4, I think it is an alias of eth_signTypedData

### DIFF
--- a/packages/react-app/src/components/WalletConnectTransactionPopUp.jsx
+++ b/packages/react-app/src/components/WalletConnectTransactionPopUp.jsx
@@ -123,6 +123,7 @@ const getTitle = (method) => {
             title = "Sign Message?";
             break;
         case "eth_signTypedData":
+        case "eth_signTypedData_v4":
             title = "Sign Typed Data?";
             break;
         default:

--- a/packages/react-app/src/helpers/WalletConnectV2Helper.js
+++ b/packages/react-app/src/helpers/WalletConnectV2Helper.js
@@ -51,7 +51,7 @@ export const onSessionProposal = async (
                 supportedNamespaces: {
                 eip155: {
                 chains: getSupportedChainIds().map(chainId => "eip155:" + chainId), // ["eip155:1", "eip155:137", ...] 
-                methods: ["eth_sendTransaction", "eth_signTransaction", "eth_sign", "personal_sign", "eth_signTypedData"],
+                methods: ["eth_sendTransaction", "eth_signTransaction", "eth_sign", "personal_sign", "eth_signTypedData", "eth_signTypedData_v4"],
                 events: ["accountsChanged", "chainChanged"],
                 accounts:getSupportedChainIds().map(chainId => "eip155:" + chainId + ":" + address) // ["eip155:1:0x8c9D11cE64289701eFEB6A68c16e849E9A2e781d", "eip155:137:0x8c9D11cE64289701eFEB6A68c16e849E9A2e781d", ...] 
                 },


### PR DESCRIPTION
Hello,

I wanted to order my gnosis card (https://gnosispay.com/) using Wallet Connect, but it failed because of this missing "**eth_signTypedData_v4**" method.

With this small change I could properly sign the message.

Cheers,
Tamas