### PR TITLE
Use Alchemy RPC for Sepolia as well

### DIFF
--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -507,7 +507,8 @@ export const NETWORKS = {
     faucet: "https://faucet.sepolia.dev/",
     blockExplorer: "https://sepolia.etherscan.io/",
     //rpcUrl: `https://rpc.sepolia.dev`,
-    rpcUrl: `https://rpc.sepolia.org/`,
+    //rpcUrl: `https://rpc.sepolia.org/`,
+    rpcUrl: `https://eth-sepolia.g.alchemy.com/v2/4vFnzFt4K0gFDvYodzTuH9ZjbGI-awSf`,
 
   },
   localhost: {


### PR DESCRIPTION
Heeey,

I'm not sure what is wrong with the official Sepolia RPCs, but non of them seem to be working which are listed on https://sepolia.dev/#.

I copied the Goerli Alchemy RPC and changed it to sepolia.

**Note:**
I guess we should store the API key in the .env file, but git history won't forget and it looks like no one is trying to use it. :)

Cheers,
Tamas