### PR TITLE
Align Punk and Blockie - rebased

### DIFF
--- a/packages/react-app/src/components/AddressInput.jsx
+++ b/packages/react-app/src/components/AddressInput.jsx
@@ -298,7 +298,7 @@ export default function AddressInput(props) {
 
   return (
     <div>
-      <div style={{ position: "absolute", left: -202, top: -88 }}>
+      <div style={{ position: "absolute", left: -202, top: 26 }}>
         {currentValue && currentValue.length > 41 ? <QRPunkBlockie scale={0.6} address={currentValue} /> : ""}
       </div>
 

--- a/packages/react-app/src/components/Monerium.jsx
+++ b/packages/react-app/src/components/Monerium.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 
 import { Button, Divider, Modal, Spin } from "antd";
-import { MoneriumBalances, MoneriumDescription, MoneriumHeader, MoneriumIban, MoneriumPunkNotConnected, LogoOnLogo, QRPunkBlockie } from "./";
+import { MoneriumBalances, MoneriumDescription, MoneriumHeader, MoneriumIban, MoneriumPunkNotConnected, LogoOnLogo } from "./";
 
 import { authorize, authorizeWithRefreshToken, getData } from "../helpers/MoneriumHelper";
 

--- a/packages/react-app/src/components/Punk.jsx
+++ b/packages/react-app/src/components/Punk.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function Punk({ address, size }) {
+  const part1 = address.substr(2, 20);
+  const part2 = address.substr(22);
+
+  const x = parseInt(part1, 16) % 100;
+  const y = parseInt(part2, 16) % 100;
+
+  return (
+    <div style={{position:"relative", width:size, height:size, overflow: "hidden"}}>
+      <img
+        src="/punks.png"
+        style={{position:"absolute", left:(-size*x), top:(-size*y), width:size*100, height:size*100, imageRendering:"pixelated"}}
+      />
+    </div>
+  );
+}

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -1,58 +1,62 @@
 import React from "react";
 import QR from 'qrcode.react';
-import { Blockie } from "."
+import { Blockie, Punk } from "."
 import { message } from 'antd';
 
-export default function QRPunkBlockie(props) {
-  const hardcodedSizeForNow = 380
+export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
+  const hardcodedSizeForNow = 380;
+  let blockieScale = 11.5;
 
-  const punkSize = 112
+  if (scale) {
+    blockieScale = blockieScale * scale;
+  }
 
-  let part1 = props.address && props.address.substr(2,20)
-  let part2= props.address && props.address.substr(22)
-  const x = parseInt(part1, 16)%100
-  const y = parseInt(part2, 16)%100
+  const punkSize = blockieScale * 8; // Make punk image the same size as the blockie, from https://github.com/ethereum/blockies: width/height of the icon in blocks, default: 8
 
   return (
-    <div style={{transform:"scale("+(props.scale?props.scale:"1")+")",transformOrigin:"50% 50%",margin:"auto", position:"relative",width:hardcodedSizeForNow}} onClick={()=>{
-       const el = document.createElement('textarea');
-       el.value = props.address;
-       document.body.appendChild(el);
-       el.select();
-       document.execCommand('copy');
-       document.body.removeChild(el);
-       const iconPunkSize = 40
-       message.success(
-         <span style={{position:"relative"}}>
-          Copied Address
-          <div style={{position:"absolute",left:-60,top:-14}}>
-            <div style={{position:"relative",width:iconPunkSize, height:iconPunkSize-1, overflow: "hidden"}}>
-              <img src="/punks.png" style={{position:"absolute",left:-iconPunkSize*x,top:(-iconPunkSize*y),width:iconPunkSize*100, height:iconPunkSize*100,imageRendering:"pixelated"}} />
-            </div>
+    <span
+      onClick={() => {
+          // Todo: this part is duplicated in MoneriumIban
+          const el = document.createElement('textarea');
+          el.value = address;
+          document.body.appendChild(el);
+          el.select();
+          document.execCommand('copy');
+          document.body.removeChild(el);
+          const iconPunkSize = 40
+          message.success(
+            <span style={{ position: "relative" }}>
+              Copied Address
+              <div style={{ position: "absolute", left: -60, top: -14, zIndex: 1 }}>
+                <Punk address={address} size={iconPunkSize}/>
+              </div>
+            </span>
+          );
+        }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: hardcodedSizeForNow, margin:"auto", position:"" }}>
+        {withQr &&
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }} >
+              <QR
+                level={"H"}
+                includeMargin={false}
+                value={address}
+                size={hardcodedSizeForNow}
+                imageSettings={{ width: 105, height: 105, excavate: true, src: "" }}
+              />
           </div>
-         </span>
-       );
-    }}>
+        }
 
-      <div style={{position:"absolute",opacity:0.5,left:hardcodedSizeForNow/2-46,top:hardcodedSizeForNow/2-46}}>
-        <Blockie address={props.address} scale={11.5}/>
-      </div>
+        <div style={{ position: 'absolute', opacity:"0.5", width:punkSize, height:punkSize }}>
+          <Blockie address={address} scale={blockieScale} />
+        </div>
 
-      <div style={{position:"absolute",left:hardcodedSizeForNow/2-53,top:hardcodedSizeForNow/2-65}}>
-        <div style={{position:"relative",width:punkSize, height:punkSize-1, overflow: "hidden"}}>
-          <img src="/punks.png" style={{position:"absolute",left:-punkSize*x,top:(-punkSize*y)-1,width:punkSize*100, height:punkSize*100,imageRendering:"pixelated"}} />
+        <div style={{ position: 'absolute' }}>
+          <Punk address={address} size={punkSize}/>
         </div>
       </div>
 
-      {props.withQr ? <QR
-        level={"H"}
-        includeMargin={false}
-        value={props.address?props.address:""}
-        size={hardcodedSizeForNow}
-        imageSettings={{width:105,height:105,excavate:true,src:""}}
-      /> : ""}
-
-      {props.showAddress ? <div style={{fontWeight:"bolder",letterSpacing:-0.8,color:"#666666",fontSize:14.8}}>{props.address}</div>: ""}
-    </div>
+      {showAddress && <div style={{marginTop:"0.39em", fontWeight:"bolder", letterSpacing:-0.8,color:"#666666", fontSize:14.8}}>{address}</div>}
+    </span>
   );
 }

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -1,27 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import QR from 'qrcode.react';
-import { Blockie, Balance } from "."
-import { message, Typography } from 'antd';
-const { Text } = Typography;
-
+import { Blockie } from "."
+import { message } from 'antd';
 
 export default function QRPunkBlockie(props) {
-
-  const size = useWindowSize();
-  const minSize = 360
-  let qrWidth
-  if(size.width / 3 < minSize) {
-    qrWidth = minSize
-  } else {
-    qrWidth = size.width / 3
-  }
-
-  let scale = Math.min(size.height-130,size.width,1024)/(qrWidth*1)
-
-  let offset =  0.42
-
-  const url  = window.location.href+""
-
   const hardcodedSizeForNow = 380
 
   const punkSize = 112
@@ -31,8 +13,6 @@ export default function QRPunkBlockie(props) {
   const x = parseInt(part1, 16)%100
   const y = parseInt(part2, 16)%100
 
-  //console.log("window.location",window.location)
-
   return (
     <div style={{transform:"scale("+(props.scale?props.scale:"1")+")",transformOrigin:"50% 50%",margin:"auto", position:"relative",width:hardcodedSizeForNow}} onClick={()=>{
        const el = document.createElement('textarea');
@@ -41,7 +21,6 @@ export default function QRPunkBlockie(props) {
        el.select();
        document.execCommand('copy');
        document.body.removeChild(el);
-       const iconHardcodedSizeForNow = 380
        const iconPunkSize = 40
        message.success(
          <span style={{position:"relative"}}>
@@ -68,44 +47,12 @@ export default function QRPunkBlockie(props) {
       {props.withQr ? <QR
         level={"H"}
         includeMargin={false}
-        //ethereum:0x34aA3F359A9D614239015126635CE7732c18fDF3
-        value={props.address?props.address:""}//"https://punkwallet.io/"+
+        value={props.address?props.address:""}
         size={hardcodedSizeForNow}
         imageSettings={{width:105,height:105,excavate:true,src:""}}
       /> : ""}
 
-
       {props.showAddress ? <div style={{fontWeight:"bolder",letterSpacing:-0.8,color:"#666666",fontSize:14.8}}>{props.address}</div>: ""}
-
     </div>
   );
-}
-
-
-function useWindowSize() {
-  const isClient = typeof window === 'object';
-
-  function getSize() {
-    return {
-      width: isClient ? window.innerWidth : undefined,
-      height: isClient ? window.innerHeight : undefined
-    };
-  }
-
-  const [windowSize, setWindowSize] = useState(getSize);
-
-  useEffect(() => {
-    if (!isClient) {
-      return false;
-    }
-
-    function handleResize() {
-      setWindowSize(getSize());
-    }
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []); // Empty array ensures that effect is only run on mount and unmount
-
-  return windowSize;
 }

--- a/packages/react-app/src/components/TransactionDisplay.jsx
+++ b/packages/react-app/src/components/TransactionDisplay.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 
 import { useLocalStorage } from "../hooks";
 
-import { LogoOnLogo, TokenDisplay, QRPunkBlockie } from "./";
+import { LogoOnLogo, TokenDisplay } from "./";
 
 import { getShortAddress } from "../helpers/MoneriumHelper";
 

--- a/packages/react-app/src/components/TransactionResponseDisplay.jsx
+++ b/packages/react-app/src/components/TransactionResponseDisplay.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 
 import { TransactionManager } from "../helpers/TransactionManager";
 
-import { TransactionDisplay, QRPunkBlockie } from "./";
+import { TransactionDisplay } from "./";
 
 import axios from "axios";
 

--- a/packages/react-app/src/components/Wallet.jsx
+++ b/packages/react-app/src/components/Wallet.jsx
@@ -228,7 +228,7 @@ export default function Wallet(props) {
               message.success(<span style={{ position: "relative" }}>Copied Private Key Link</span>);
             }}
           >
-            <div style={{position:"relative",top:34,left:-11}}>
+            <div style={{position:"relative",top:224,left:-11}}>
               <QRPunkBlockie withQr={false} address={selectedAddress} />
             </div>
 

--- a/packages/react-app/src/components/WalletImport.jsx
+++ b/packages/react-app/src/components/WalletImport.jsx
@@ -74,19 +74,15 @@ export default function WalletImport({setShowImport}) {
 	      setImportPrivatekey(e.target.value)
 	    }}/>
 
-	    <hr/>
-
-	    {importAddress ? 
+	    {importAddress &&
 	    	<div style={{width:420,height:200}}>
 		      <div style={{float:"right",marginTop:64}}>
 		        <Address value={importAddress}/>
 		      </div>
-		      <div style={{ position:"relative", top:-100, left:-100}}>
+		      <div style={{ position:"relative", top:-19, left:-100}}>
 		      	<QRPunkBlockie withQr={false} address={importAddress} />
 					</div>
-					<hr/>
 				</div>
-				:""
 			}
 
 			<div style={{float:'right'}}>

--- a/packages/react-app/src/components/index.js
+++ b/packages/react-app/src/components/index.js
@@ -21,6 +21,7 @@ export { default as MoneriumIban } from "./MoneriumIban";
 export { default as MoneriumPunkNotConnected } from "./MoneriumPunkNotConnected";
 export { default as NetworkDisplay } from "./NetworkDisplay";
 export { default as Provider } from "./Provider";
+export { default as Punk } from "./Punk";
 export { default as QRPunkBlockie } from "./QRPunkBlockie";
 export { default as Ramp } from "./Ramp";
 export { default as SelectorWithSettings } from "./SelectorWithSettings";


### PR DESCRIPTION
This PR aligns the elements to the middle with flex, this seems a lot cleaner to me than the previous pixel calculations.

The Punk image used to be a little bit bigger, the Blockie and the Punk should be the same size imho, this is how we show it on app.buidlguidl.com as well.

<img width="547" alt="image" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/040539ec-d7be-4430-97c1-447b56e6a24e">


![image](https://github.com/scaffold-eth/punk-wallet/assets/1397179/add181e9-5eba-47e5-a99b-7260a682b588)
