### PR TITLE
Add option to enlarge punk

### DIFF
--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -3,7 +3,9 @@ import QR from 'qrcode.react';
 import { Blockie, Punk } from "."
 import { message } from 'antd';
 
-export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
+export default function QRPunkBlockie({ address, showAddress, withQr, scale, enlargePunk = false }) {
+  const qrImageSize = 105;
+
   const hardcodedSizeForNow = 380;
   let blockieScale = 11.5;
 
@@ -11,7 +13,24 @@ export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
     blockieScale = blockieScale * scale;
   }
 
-  const punkSize = blockieScale * 8; // Make punk image the same size as the blockie, from https://github.com/ethereum/blockies: width/height of the icon in blocks, default: 8
+  // Make punk image the same size as the blockie,
+  // from https://github.com/ethereum/blockies: width/height of the icon in blocks, default: 8
+  const blockieSize = blockieScale * 8
+  let punkSize = blockieSize; 
+
+  let paddingBottom;
+
+  if (enlargePunk) {
+    const maxEnlargementPercentage = qrImageSize / punkSize;
+
+    const halfOfMaxEnlargementPercentage = ((maxEnlargementPercentage * 100 - 100) / 2 + 100) / 100;
+
+    const originalPunkSize = punkSize;
+
+    punkSize = punkSize * halfOfMaxEnlargementPercentage;
+
+    paddingBottom = punkSize - originalPunkSize;
+  }
 
   return (
     <span
@@ -42,16 +61,16 @@ export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
                 includeMargin={false}
                 value={address}
                 size={hardcodedSizeForNow}
-                imageSettings={{ width: 105, height: 105, excavate: true, src: "" }}
+                imageSettings={{ width: qrImageSize, height: qrImageSize, excavate: true, src: "" }}
               />
           </div>
         }
 
-        <div style={{ position: 'absolute', opacity:"0.5", width:punkSize, height:punkSize }}>
+        <div style={{ position: 'absolute', opacity:"0.5", width:blockieSize, height:blockieSize }}>
           <Blockie address={address} scale={blockieScale} />
         </div>
 
-        <div style={{ position: 'absolute' }}>
+        <div style={{ position: 'absolute', paddingBottom:paddingBottom }}>
           <Punk address={address} size={punkSize}/>
         </div>
       </div>


### PR DESCRIPTION
Currently **enlargePunk**  is set to false.
Here are a few before/after comparisons.

Currently the enlargement is set to max (do not interfere with the QR code)  / 2.
The last image was created with max instead of the mentioned max / 2.

<img width="1512" alt="Screenshot 2023-11-29 at 14 16 50" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/06755651-d5af-49f6-b30c-70174080c882">
<img width="1512" alt="Screenshot 2023-11-29 at 14 16 57" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/76971cee-5e7d-4873-bad3-4bd84591512f">
<img width="1512" alt="Screenshot 2023-11-29 at 14 17 27" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/7f68341c-c288-4d3b-b913-7f65e745525d">
<img width="1512" alt="Screenshot 2023-11-29 at 14 17 33" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/6b6c3457-6aa7-453b-961b-e0d17ad33130">
<img width="1512" alt="Screenshot 2023-11-29 at 14 18 35" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/9df57138-9daa-4d51-98e8-4e1751a784a5">
