### PR TITLE
Fetch ERC20 token prices with LI.FI API

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -121,6 +121,8 @@ const DEBUG = false;
 const networks = Object.values(NETWORKS);
 
 function App(props) {
+  const [dollarMode, setDollarMode] = useLocalStorage("dollarMode", true);
+
   const [networkSettingsModalOpen, setNetworkSettingsModalOpen] = useState(false);
   const [networkSettings, setNetworkSettings] = useLocalStorage(NETWORK_SETTINGS_STORAGE_KEY, {});
   const networkSettingsHelper = new SettingsHelper(NETWORK_SETTINGS_STORAGE_KEY, networks, networkSettings, setNetworkSettings, getNetworkWithSettings);
@@ -1014,16 +1016,22 @@ function App(props) {
         <div>
           {selectedErc20Token ?
             <ERC20Balance
+              targetNetwork={targetNetwork}
               token={selectedErc20Token}
               rpcURL={targetNetwork.rpcUrl}
               size={12 + window.innerWidth / 16}
               address={address}
+              dollarMode={dollarMode}
+              setDollarMode={setDollarMode}
             />
             :
             <Balance
               value={yourLocalBalance}
               size={12 + window.innerWidth / 16}
-              price={price} />
+              price={price}
+              dollarMode={dollarMode}
+              setDollarMode={setDollarMode}
+            />
           }
         </div>
 

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -29,9 +29,10 @@ import { useBalance } from "../hooks";
 */
 
 export default function Balance(props) {
-  const [dollarMode, setDollarMode] = useState(true);
-
   // const [listening, setListening] = useState(false);
+
+  const dollarMode = props.dollarMode;
+  const setDollarMode = props.setDollarMode;
 
   const balance = useBalance(props.provider, props.address);
 

--- a/packages/react-app/src/components/ERC20Balance.jsx
+++ b/packages/react-app/src/components/ERC20Balance.jsx
@@ -4,9 +4,27 @@ import { Spin } from "antd";
 
 import { getTokenBalance } from "../helpers/ERC20Helper";
 
-export default function ERC20Balance({token, rpcURL, size, address}) {
+import { getTokenPrice } from "../helpers/LiFiTokenPriceHelper";
+
+export default function ERC20Balance({targetNetwork, token, rpcURL, size, address, dollarMode, setDollarMode}) {
     const [balance, setBalance] = useState(null);
+    const [price, setPrice] = useState(0);
+
     const [loading, setLoading] = useState(true);
+
+    // ToDo: Update balance after we hit Send
+
+    // ToDo: Get rid of the error:
+    // Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
+    // https://medium.com/doctolib/react-stop-checking-if-your-component-is-mounted-3bb2568a4934
+
+    useEffect(() => {
+        async function getPrice() {
+            setPrice(await getTokenPrice(targetNetwork.chainId, token.address));
+        }
+
+        getPrice();
+    }, [targetNetwork, token])
 
     useEffect(() => {
         async function getBalance() {
@@ -31,11 +49,19 @@ export default function ERC20Balance({token, rpcURL, size, address}) {
 
     return (
         <div>
-            <span style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8,}} >
+            <span
+                style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8, cursor: "pointer"}} 
+                onClick={() => {
+                    setDollarMode(!dollarMode);
+                }}
+            >
                 {loading ? 
                     <Spin/>
                     : 
-                    balance && balance
+                    balance && (
+                        (dollarMode && (price != 0)) ? "$" + (balance * price).toFixed(2) :
+                        balance
+                    )
                 }
             </span>
         </div>

--- a/packages/react-app/src/helpers/LiFiTokenPriceHelper.js
+++ b/packages/react-app/src/helpers/LiFiTokenPriceHelper.js
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+const API_BASE_URL = "https://li.quest/v1/token";
+
+export const getTokenPrice = async (chainId, address) => {
+	try {
+		const apiURL = API_BASE_URL + `?chain=${chainId}&token=${address}`;
+
+		const tokenInfo = (await axios.get(apiURL)).data;
+
+		return tokenInfo.priceUSD;	
+	}
+	catch (error) {
+		console.error(
+			`Couldn't fetch token price for ${chainId} ${address} , maybe there is a rate limit`, error);
+
+		return 0;
+	}	
+}


### PR DESCRIPTION
This PR is about fetching token prices with the [Li.Fi API](https://docs.li.fi/li.fi-api/li.fi-api).
Also, "dollarMode" was moved to local storage, so if we change the default dollarMode to the token/eth amount, this setting will be remembered after a page refresh.

https://github.com/scaffold-eth/punk-wallet/assets/1397179/bbc3d297-8f72-498b-9caf-2cae93ed37d9

**Notes:**
Token balances should be refreshed after we sent some.
Switching between tokens/networks quickly can trigger the "Can't perform a React state update on an unmounted component." error, because fetching the balance/price is async and the results might arrive when we already switched to another token, and I was too lazy to solve this right now.
There might be a rate limit error from LI.FI, I just wanted to see if this can be a solution.