### PR TITLE
Fetch ERC20 token prices with LI.FI API

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -138,6 +138,8 @@ const DEBUG = false;
 const networks = Object.values(NETWORKS);
 
 function App(props) {
+  const [dollarMode, setDollarMode] = useLocalStorage("dollarMode", true);
+
   const [networkSettingsModalOpen, setNetworkSettingsModalOpen] = useState(false);
   const [networkSettings, setNetworkSettings] = useLocalStorage(NETWORK_SETTINGS_STORAGE_KEY, {});
   const networkSettingsHelper = new SettingsHelper(
@@ -369,7 +371,7 @@ function App(props) {
   const isIbanTransferReady =
     moneriumConnected && punkConnectedToMonerium && selectedErc20Token && selectedErc20Token.name == "EURe";
 
-  // if you don't have any money, scan the other networks for money
+  // if you don't have any money, scan the other net;works for money
   // lol this poller is a bad idea why does it keep
   /*usePoller(() => {
     if (!cachedNetwork) {
@@ -1082,13 +1084,22 @@ function App(props) {
         <div>
           {selectedErc20Token ? (
             <ERC20Balance
+              targetNetwork={targetNetwork}
               token={selectedErc20Token}
               rpcURL={targetNetwork.rpcUrl}
               size={12 + window.innerWidth / 16}
               address={address}
+              dollarMode={dollarMode}
+              setDollarMode={setDollarMode}
             />
           ) : (
-            <Balance value={yourLocalBalance} size={12 + window.innerWidth / 16} price={price} />
+            <Balance
+              value={yourLocalBalance}
+              size={12 + window.innerWidth / 16}
+              price={price}
+              dollarMode={dollarMode}
+              setDollarMode={setDollarMode}
+            />
           )}
         </div>
 

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -29,9 +29,10 @@ import { useBalance } from "../hooks";
 */
 
 export default function Balance(props) {
-  const [dollarMode, setDollarMode] = useState(true);
-
   // const [listening, setListening] = useState(false);
+
+  const dollarMode = props.dollarMode;
+  const setDollarMode = props.setDollarMode;
 
   const balance = useBalance(props.provider, props.address);
 

--- a/packages/react-app/src/components/ERC20Balance.jsx
+++ b/packages/react-app/src/components/ERC20Balance.jsx
@@ -4,9 +4,29 @@ import { Spin } from "antd";
 
 import { getTokenBalance } from "../helpers/ERC20Helper";
 
-export default function ERC20Balance({ token, rpcURL, size, address }) {
+import { getTokenPrice } from "../helpers/LiFiTokenPriceHelper";
+
+export default function ERC20Balance({ targetNetwork, token, rpcURL, size, address, dollarMode, setDollarMode }) {
   const [balance, setBalance] = useState(null);
+  const [price, setPrice] = useState(0);
+
   const [loading, setLoading] = useState(true);
+
+  // ToDo: Update balance after we hit Send
+
+  // ToDo: Get rid of the error (when switching networks qickly):
+  // Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
+  // https://medium.com/doctolib/react-stop-checking-if-your-component-is-mounted-3bb2568a4934
+
+  // ToDo: Switch between token amount and token price, same as how we can switch between ETH and USD
+
+  useEffect(() => {
+    async function getPrice() {
+      setPrice(await getTokenPrice(targetNetwork.chainId, token.address));
+    }
+
+    getPrice();
+  }, [targetNetwork, token]);
 
   useEffect(() => {
     async function getBalance() {
@@ -30,8 +50,13 @@ export default function ERC20Balance({ token, rpcURL, size, address }) {
 
   return (
     <div>
-      <span style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8 }}>
-        {loading ? <Spin /> : balance && balance}
+      <span
+        style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8, cursor: "pointer" }}
+        onClick={() => {
+          setDollarMode(!dollarMode);
+        }}
+      >
+        {loading ? <Spin /> : balance && (dollarMode && price != 0 ? "$" + (balance * price).toFixed(2) : balance)}
       </span>
     </div>
   );

--- a/packages/react-app/src/components/ERC20Balance.jsx
+++ b/packages/react-app/src/components/ERC20Balance.jsx
@@ -4,40 +4,35 @@ import { Spin } from "antd";
 
 import { getTokenBalance } from "../helpers/ERC20Helper";
 
-export default function ERC20Balance({token, rpcURL, size, address}) {
-    const [balance, setBalance] = useState(null);
-    const [loading, setLoading] = useState(true);
+export default function ERC20Balance({ token, rpcURL, size, address }) {
+  const [balance, setBalance] = useState(null);
+  const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        async function getBalance() {
-            if (!address) {
-                return;
-            }
+  useEffect(() => {
+    async function getBalance() {
+      if (!address) {
+        return;
+      }
 
-            setLoading(true);
+      setLoading(true);
 
-            try {
-                setBalance(await getTokenBalance(token, rpcURL, address));
-            }
-            catch (error) {
-                console.error("Coudn't fetch balance", error)
-            }
+      try {
+        setBalance(await getTokenBalance(token, rpcURL, address));
+      } catch (error) {
+        console.error("Coudn't fetch balance", error);
+      }
 
-            setLoading(false);
-        }
+      setLoading(false);
+    }
 
-        getBalance();
-    }, [address, token, rpcURL])
+    getBalance();
+  }, [address, token, rpcURL]);
 
-    return (
-        <div>
-            <span style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8,}} >
-                {loading ? 
-                    <Spin/>
-                    : 
-                    balance && balance
-                }
-            </span>
-        </div>
-    );
+  return (
+    <div>
+      <span style={{ verticalAlign: "middle", fontSize: size ? size : 24, padding: 8 }}>
+        {loading ? <Spin /> : balance && balance}
+      </span>
+    </div>
+  );
 }

--- a/packages/react-app/src/helpers/LiFiTokenPriceHelper.js
+++ b/packages/react-app/src/helpers/LiFiTokenPriceHelper.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const API_BASE_URL = "https://li.quest/v1/token";
+
+export const getTokenPrice = async (chainId, address) => {
+	try {
+		const apiURL = API_BASE_URL + `?chain=${chainId}&token=${address}`;
+
+		const tokenInfo = (await axios.get(apiURL)).data;
+
+		return tokenInfo.priceUSD;
+	} catch (error) {
+		console.error(`Couldn't fetch token price for ${chainId} ${address} , maybe there is a rate limit`, error);
+
+		return 0;
+	}
+};


### PR DESCRIPTION
This PR is about fetching token prices with the [Li.Fi API](https://docs.li.fi/li.fi-api/li.fi-api).
Also, "dollarMode" was moved to local storage, so if we change the default dollarMode to the token/eth amount, this setting will be remembered after a page refresh.

**Notes:**

- Token balances should be refreshed after we sent some.
- Switching between tokens/networks quickly can trigger the "Can't perform a React state update on an unmounted component." error, because fetching the balance/price is async and the results might arrive when we already switched to another token, and I was too lazy to solve this right now.
- There might be a rate limit error from LI.FI, I just wanted to see if this can be a solution.
- It would be nice if we could switch between the token amount and the price the same way as it works for ETH/USD right now

https://github.com/scaffold-eth/punk-wallet/assets/1397179/bbc3d297-8f72-498b-9caf-2cae93ed37d9

