### PR TITLE
Copy button on Token Detailed View

### DIFF
--- a/packages/react-app/src/components/MoneriumIban.jsx
+++ b/packages/react-app/src/components/MoneriumIban.jsx
@@ -5,34 +5,15 @@ import QR from "qrcode.react";
 import { Alert, Input, message } from "antd";
 import { CopyOutlined, QrcodeOutlined, WarningOutlined } from "@ant-design/icons";
 
-import { LogoOnLogo, TokenDisplay } from "./";
-import { getShortAddress } from "../helpers/MoneriumHelper";
 import { useLocalStorage } from "../hooks";
+
+import { LogoOnLogo, TokenDisplay } from "./";
+
+import { copy } from "../helpers/EditorHelper";
+import { getShortAddress } from "../helpers/MoneriumHelper";
 
 //const generateQrCode = require('sepa-payment-qr-code')
 import { generateQrCode } from "../helpers/SepaPaymentQrCodeHelper";
-
-const handleCopy = async iban => {
-  let copySuccessful = false;
-
-  try {
-    await navigator.clipboard.writeText(iban);
-    copySuccessful = true;
-  } catch (error) {
-    console.error("navigator.clipboard.writeText is not supported by your browser", error);
-  }
-
-  if (!copySuccessful) {
-    const el = document.createElement("textarea");
-    el.value = iban;
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand("copy");
-    document.body.removeChild(el);
-  }
-
-  message.success(<span style={{ position: "relative" }}>Copied IBAN</span>);
-};
 
 export default function MoneriumIban({ clientData, currentPunkAddress }) {
   const accountArrayIban = clientData.accountArrayIban;
@@ -118,9 +99,7 @@ export default function MoneriumIban({ clientData, currentPunkAddress }) {
 
         <div
           style={{ display: "flex", flexDirection: "column", backgroundColor: "", cursor: "pointer" }}
-          onClick={() => {
-            handleCopy(iban);
-          }}
+          onClick={() => copy(iban, () => message.success(<span style={{ position: "relative" }}>Copied IBAN</span>))}
         >
           <div style={{ alignItems: "flex-start" }}>
             <div

--- a/packages/react-app/src/components/MoneriumIban.jsx
+++ b/packages/react-app/src/components/MoneriumIban.jsx
@@ -1,232 +1,201 @@
 import React, { useState } from "react";
 
-import QR from 'qrcode.react';
+import QR from "qrcode.react";
 
 import { Alert, Input, message } from "antd";
 import { CopyOutlined, QrcodeOutlined, WarningOutlined } from "@ant-design/icons";
 
 import { LogoOnLogo, TokenDisplay } from "./";
 import { getShortAddress } from "../helpers/MoneriumHelper";
-import { useLocalStorage} from "../hooks";
+import { useLocalStorage } from "../hooks";
 
 //const generateQrCode = require('sepa-payment-qr-code')
 import { generateQrCode } from "../helpers/SepaPaymentQrCodeHelper";
 
-const handleCopy = async (iban) => {
-    let copySuccessful = false;
+const handleCopy = async iban => {
+  let copySuccessful = false;
 
-    try {
-        await navigator.clipboard.writeText(iban);
-        copySuccessful = true;
-    }
-    catch (error) {
-        console.error("navigator.clipboard.writeText is not supported by your browser", error);
-    }
-
-    if (!copySuccessful) {
-        const el = document.createElement('textarea');
-        el.value = iban;
-        document.body.appendChild(el);
-        el.select();
-        document.execCommand('copy');
-        document.body.removeChild(el);
-    }
-
-    message.success(
-        <span style={{position:"relative"}}>
-            Copied IBAN
-        </span>
-    );
+  try {
+    await navigator.clipboard.writeText(iban);
+    copySuccessful = true;
+  } catch (error) {
+    console.error("navigator.clipboard.writeText is not supported by your browser", error);
   }
 
-export default function MoneriumIban( { clientData, currentPunkAddress } ) {
-    const accountArrayIban = clientData.accountArrayIban;
-    const ibanObject = accountArrayIban[0]; // ToDo: Handle multiple ibans
-    const ibanAccountAddress = ibanObject?.address;
+  if (!copySuccessful) {
+    const el = document.createElement("textarea");
+    el.value = iban;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  }
 
-    const name = clientData.name;
-    const iban = ibanObject?.iban;
+  message.success(<span style={{ position: "relative" }}>Copied IBAN</span>);
+};
 
-    let ibanAccountAddressIsDifferent = false;
+export default function MoneriumIban({ clientData, currentPunkAddress }) {
+  const accountArrayIban = clientData.accountArrayIban;
+  const ibanObject = accountArrayIban[0]; // ToDo: Handle multiple ibans
+  const ibanAccountAddress = ibanObject?.address;
 
-    if (currentPunkAddress.toLowerCase() != ibanAccountAddress?.toLowerCase()) {
-        ibanAccountAddressIsDifferent = true;
-    }
+  const name = clientData.name;
+  const iban = ibanObject?.iban;
 
-    const [amount, setAmount] = useState("");
-    const [memo, setMemo] = useState("");
+  let ibanAccountAddressIsDifferent = false;
 
-    const [showIbanQR, setShowIbanQR] = useLocalStorage("showIbanQR", true); 
-    const [showWarningMessage, setShowWarningMessage] = useLocalStorage("showIbanWarning", true); 
+  if (currentPunkAddress.toLowerCase() != ibanAccountAddress?.toLowerCase()) {
+    ibanAccountAddressIsDifferent = true;
+  }
 
-    if (!ibanAccountAddress) {
-        return (<></>);        
-    }
+  const [amount, setAmount] = useState("");
+  const [memo, setMemo] = useState("");
 
-    let qrObject = {
-        name: name,
-        iban: iban,
-    }
+  const [showIbanQR, setShowIbanQR] = useLocalStorage("showIbanQR", true);
+  const [showWarningMessage, setShowWarningMessage] = useLocalStorage("showIbanWarning", true);
 
-    let isValidAmount = false;
-    const amountNumber = parseFloat(parseFloat(amount.replace(/,/g, '.')).toFixed(2));
+  if (!ibanAccountAddress) {
+    return <></>;
+  }
 
-    if (!isNaN(amountNumber) && ((amountNumber >= 0.01) && (amountNumber <= 999999999.99))) {
-        isValidAmount = true;
-        qrObject.amount = amountNumber;
-    }
+  let qrObject = {
+    name: name,
+    iban: iban,
+  };
 
-    if (memo) {
-        qrObject.unstructuredReference = memo;
-    }
+  let isValidAmount = false;
+  const amountNumber = parseFloat(parseFloat(amount.replace(/,/g, ".")).toFixed(2));
 
-    const qr = generateQrCode(qrObject);
+  if (!isNaN(amountNumber) && amountNumber >= 0.01 && amountNumber <= 999999999.99) {
+    isValidAmount = true;
+    qrObject.amount = amountNumber;
+  }
 
-    return (
-        <>
-            {ibanAccountAddressIsDifferent && 
-                <div style={{ display: 'flex', justifyContent: 'space-around', alignItems:"center", paddingBottom:"2em" }}>
-                    {showWarningMessage && 
-                        <div>
-                            <Alert
-                                type={"warning"}
-                                message={
-                                    <div style={{ display: 'flex', flexDirection:"column", justifyContent: 'center', alignItems:"center" }}>
-                                        <div>
-                                            Your <b>IBAN</b> is connected to a different account:
-                                        </div>
-                                        <div style={{ fontWeight:"bold" }}>
-                                            {getShortAddress(ibanAccountAddress)}
-                                        </div>
-                                    </div>
-                                }
-                            />
-                        </div>
-                    }
-                    <div 
-                        style={{ fontSize: "3em", cursor: "pointer", backgroundColor: "" }}
-                        onClick={
-                            () => {
-                                setShowWarningMessage(!showWarningMessage)
-                            } 
-                        }
-                    >
-                        <WarningOutlined style={{ color: showWarningMessage ? "black" : "gray"}}/>
+  if (memo) {
+    qrObject.unstructuredReference = memo;
+  }
+
+  const qr = generateQrCode(qrObject);
+
+  return (
+    <>
+      {ibanAccountAddressIsDifferent && (
+        <div style={{ display: "flex", justifyContent: "space-around", alignItems: "center", paddingBottom: "2em" }}>
+          {showWarningMessage && (
+            <div>
+              <Alert
+                type={"warning"}
+                message={
+                  <div
+                    style={{ display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center" }}
+                  >
+                    <div>
+                      Your <b>IBAN</b> is connected to a different account:
                     </div>
-                </div>    
-            }
-
-            <div style={{ display: 'flex', justifyContent: 'space-around', alignItems:"center", backgroundColor: "ghostwhite" }}>
-                <div>
-                    <LogoOnLogo
-                        src1={"EURe.png"}
-                        src2={"polygon-bgfill-icon.svg"}
-                        sizeMultiplier1={3}
-                        sizeMultiplier2={0.5}
-                    />
-                </div>
-
-                <div 
-                    style={{ display: 'flex', flexDirection: 'column', backgroundColor: "", cursor: "pointer" }}
-                    onClick={ () => {
-                        handleCopy(iban);
-                    }}
-                >
-                <div style={{ alignItems: "flex-start" }}>
-                    <div style={{ display: "flex", alignItems: "center", justifyContent:"center", backgroundColor: "", fontWeight: 'bold' }}>
-                        IBAN:
-                    </div>
-                </div>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                        {iban} <CopyOutlined style={{ color: "#000000", fontSize: 18, marginLeft: '0.5em' }} />
-                    </div>
-                </div>
-
-                <div 
-                    style={{ fontSize: "3em", cursor: "pointer", backgroundColor: "" }}
-                    onClick={
-                        () => {
-                            setShowIbanQR(!showIbanQR)
-                        } 
-                    }
-                >
-                    <QrcodeOutlined style={{ color: showIbanQR ? "black" : "gray"}}/>
-                </div>
+                    <div style={{ fontWeight: "bold" }}>{getShortAddress(ibanAccountAddress)}</div>
+                  </div>
+                }
+              />
             </div>
+          )}
+          <div
+            style={{ fontSize: "3em", cursor: "pointer", backgroundColor: "" }}
+            onClick={() => {
+              setShowWarningMessage(!showWarningMessage);
+            }}
+          >
+            <WarningOutlined style={{ color: showWarningMessage ? "black" : "gray" }} />
+          </div>
+        </div>
+      )}
 
-            {showIbanQR && <div style={{ display: 'flex', flexDirection:"column", justifyContent: 'center', alignItems:"center", paddingTop:"2em" }}>
-                <QR
-                    level={"M"}
-                    includeMargin={false}
-                    value={qr}
-                    style={{ height: "auto", maxWidth: "100%", width: "60%" }}
-                />
+      <div
+        style={{ display: "flex", justifyContent: "space-around", alignItems: "center", backgroundColor: "ghostwhite" }}
+      >
+        <div>
+          <LogoOnLogo src1={"EURe.png"} src2={"polygon-bgfill-icon.svg"} sizeMultiplier1={3} sizeMultiplier2={0.5} />
+        </div>
 
-                {name && 
-                    <div>
-                        {name}
-                    </div>
-                }
-                {iban && 
-                    <div>
-                        {iban}
-                    </div>
-                }
-                {isValidAmount && 
-                    <div>
-                        {"€ " + amountNumber}
-                    </div>
-                }
-                {memo && 
-                    <div>
-                        {memo}
-                    </div>
-                }
-
-                <div style={{ display: 'flex', flexDirection:"column", justifyContent: 'center', alignItems:"center", paddingTop:"2em" }}>
-                    <Input
-                        style={{ paddingBottom:"1em" }}
-                        value={amount}
-                        placeholder={"amount in " + "EURe"}
-                        addonAfter={<TokenDisplay token={{name:"EURe", imgSrc:"EURe.png"}}/>}
-                        onChange={async e => {
-                          setAmount(e.target.value);
-                        }}
-                    />
-                    <Input
-                        value={memo}
-                        placeholder={"Thx for the pizza"}
-                        addonAfter={<>Memo</>}
-                        onChange={async e => {
-                          setMemo(e.target.value);
-                        }}
-                    />
-                </div>
+        <div
+          style={{ display: "flex", flexDirection: "column", backgroundColor: "", cursor: "pointer" }}
+          onClick={() => {
+            handleCopy(iban);
+          }}
+        >
+          <div style={{ alignItems: "flex-start" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: "",
+                fontWeight: "bold",
+              }}
+            >
+              IBAN:
             </div>
-            }
-        </>
-    );
+          </div>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            {iban} <CopyOutlined style={{ color: "#000000", fontSize: 18, marginLeft: "0.5em" }} />
+          </div>
+        </div>
+
+        <div
+          style={{ fontSize: "3em", cursor: "pointer", backgroundColor: "" }}
+          onClick={() => {
+            setShowIbanQR(!showIbanQR);
+          }}
+        >
+          <QrcodeOutlined style={{ color: showIbanQR ? "black" : "gray" }} />
+        </div>
+      </div>
+
+      {showIbanQR && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            paddingTop: "2em",
+          }}
+        >
+          <QR level={"M"} includeMargin={false} value={qr} style={{ height: "auto", maxWidth: "100%", width: "60%" }} />
+
+          {name && <div>{name}</div>}
+          {iban && <div>{iban}</div>}
+          {isValidAmount && <div>{"€ " + amountNumber}</div>}
+          {memo && <div>{memo}</div>}
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              paddingTop: "2em",
+            }}
+          >
+            <Input
+              style={{ paddingBottom: "1em" }}
+              value={amount}
+              placeholder={"amount in " + "EURe"}
+              addonAfter={<TokenDisplay token={{ name: "EURe", imgSrc: "EURe.png" }} />}
+              onChange={async e => {
+                setAmount(e.target.value);
+              }}
+            />
+            <Input
+              value={memo}
+              placeholder={"Thx for the pizza"}
+              addonAfter={<>Memo</>}
+              onChange={async e => {
+                setMemo(e.target.value);
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/react-app/src/components/PasteButton.jsx
+++ b/packages/react-app/src/components/PasteButton.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import { Button, Tooltip } from "antd";
-import { CopyOutlined } from "@ant-design/icons";
+import { SnippetsOutlined } from "@ant-design/icons";
 
 export default function PasteButton({ setState }) {
 	return (
 		<Tooltip title="Paste">
 			<Button
-				icon={<CopyOutlined />}
+				icon={<SnippetsOutlined />}
 				onClick={async () => {
 					try {
 						const text = await navigator.clipboard.readText();

--- a/packages/react-app/src/components/PasteButton.jsx
+++ b/packages/react-app/src/components/PasteButton.jsx
@@ -6,18 +6,17 @@ import { CopyOutlined } from "@ant-design/icons";
 export default function PasteButton({ setState }) {
 	return (
 		<Tooltip title="Paste">
-         	<Button
-         		icon={<CopyOutlined />} 
-         		onClick={ async () => {	
+			<Button
+				icon={<CopyOutlined />}
+				onClick={async () => {
 					try {
 						const text = await navigator.clipboard.readText();
 						setState(text);
-					}
-					catch (err) {
-						console.error('Failed to read clipboard:', err);
+					} catch (err) {
+						console.error("Failed to read clipboard:", err);
 					}
 				}}
-         	/>
-        </Tooltip>
+			/>
+		</Tooltip>
 	);
-};
+}

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import QR from "qrcode.react";
-import { Blockie, Punk } from ".";
 import { message } from "antd";
+
+import { Blockie, Punk } from ".";
+
+import { copy } from "../helpers/EditorHelper";
 
 export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
   const hardcodedSizeForNow = 380;
@@ -15,24 +18,18 @@ export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
 
   return (
     <span
-      onClick={() => {
-        // Todo: this part is duplicated in MoneriumIban
-        const el = document.createElement("textarea");
-        el.value = address;
-        document.body.appendChild(el);
-        el.select();
-        document.execCommand("copy");
-        document.body.removeChild(el);
-        const iconPunkSize = 40;
-        message.success(
-          <span style={{ position: "relative" }}>
-            Copied Address
-            <div style={{ position: "absolute", left: -60, top: -14, zIndex: 1 }}>
-              <Punk address={address} size={iconPunkSize} />
-            </div>
-          </span>,
-        );
-      }}
+      onClick={() =>
+        copy(address, () =>
+          message.success(
+            <span style={{ position: "relative" }}>
+              Copied Address
+              <div style={{ position: "absolute", left: -60, top: -14, zIndex: 1 }}>
+                <Punk address={address} size={40} />
+              </div>
+            </span>,
+          ),
+        )
+      }
     >
       <div
         style={{

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -1,7 +1,7 @@
 import React from "react";
-import QR from 'qrcode.react';
-import { Blockie, Punk } from "."
-import { message } from 'antd';
+import QR from "qrcode.react";
+import { Blockie, Punk } from ".";
+import { message } from "antd";
 
 export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
   const hardcodedSizeForNow = 380;
@@ -16,47 +16,62 @@ export default function QRPunkBlockie({ address, showAddress, withQr, scale }) {
   return (
     <span
       onClick={() => {
-          // Todo: this part is duplicated in MoneriumIban
-          const el = document.createElement('textarea');
-          el.value = address;
-          document.body.appendChild(el);
-          el.select();
-          document.execCommand('copy');
-          document.body.removeChild(el);
-          const iconPunkSize = 40
-          message.success(
-            <span style={{ position: "relative" }}>
-              Copied Address
-              <div style={{ position: "absolute", left: -60, top: -14, zIndex: 1 }}>
-                <Punk address={address} size={iconPunkSize}/>
-              </div>
-            </span>
-          );
-        }}
+        // Todo: this part is duplicated in MoneriumIban
+        const el = document.createElement("textarea");
+        el.value = address;
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+        const iconPunkSize = 40;
+        message.success(
+          <span style={{ position: "relative" }}>
+            Copied Address
+            <div style={{ position: "absolute", left: -60, top: -14, zIndex: 1 }}>
+              <Punk address={address} size={iconPunkSize} />
+            </div>
+          </span>,
+        );
+      }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: hardcodedSizeForNow, margin:"auto", position:"" }}>
-        {withQr &&
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }} >
-              <QR
-                level={"H"}
-                includeMargin={false}
-                value={address}
-                size={hardcodedSizeForNow}
-                imageSettings={{ width: 105, height: 105, excavate: true, src: "" }}
-              />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: hardcodedSizeForNow,
+          margin: "auto",
+          position: "",
+        }}
+      >
+        {withQr && (
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <QR
+              level={"H"}
+              includeMargin={false}
+              value={address}
+              size={hardcodedSizeForNow}
+              imageSettings={{ width: 105, height: 105, excavate: true, src: "" }}
+            />
           </div>
-        }
+        )}
 
-        <div style={{ position: 'absolute', opacity:"0.5", width:punkSize, height:punkSize }}>
+        <div style={{ position: "absolute", opacity: "0.5", width: punkSize, height: punkSize }}>
           <Blockie address={address} scale={blockieScale} />
         </div>
 
-        <div style={{ position: 'absolute' }}>
-          <Punk address={address} size={punkSize}/>
+        <div style={{ position: "absolute" }}>
+          <Punk address={address} size={punkSize} />
         </div>
       </div>
 
-      {showAddress && <div style={{marginTop:"0.39em", fontWeight:"bolder", letterSpacing:-0.8,color:"#666666", fontSize:14.8}}>{address}</div>}
+      {showAddress && (
+        <div
+          style={{ marginTop: "0.39em", fontWeight: "bolder", letterSpacing: -0.8, color: "#666666", fontSize: 14.8 }}
+        >
+          {address}
+        </div>
+      )}
     </span>
   );
 }

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
-import { Button } from "antd";
-import { DeleteOutlined } from "@ant-design/icons";
+import { Button, message } from "antd";
+import { CopyOutlined, DeleteOutlined } from "@ant-design/icons";
 
 import { copy } from "../helpers/EditorHelper";
 
@@ -24,49 +24,33 @@ export default function TokenDetailedDisplay({
 
       <div
         style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
           paddingTop: setItemDetailed ? "1em" : "0.5em",
         }}
       >
         {token.hasOwnProperty("address") ? (
-          <>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
             <div
               style={{
                 cursor: "pointer",
                 color: `var(--link-color)`,
                 fontSize: "15px",
-                marginRight: "7px",
+                marginRight: "15px",
               }}
               onClick={() => window.open(tokenLink, "_blank")}
             >
               {token.address}
-
-              {/* ToDo: A copy button might be better here - added but still has the link capability */}
-              <img src="/open_in_new.svg" alt="open_in_new.svg" style={{ paddingBottom: "0.2em" }} />
             </div>
-            <div
-              style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
-              onClick={() => copy(token.address)}
-            >
-              {addressCopied ? (
-                <img
-                  src="/greenCheckmark.svg"
-                  alt="Copy"
-                  style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
-                />
-              ) : (
-                <img
-                  src="/paste-svgrepo-com.svg"
-                  alt="Copy"
-                  style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
-                />
-              )}
-            </div>
-          </>
+            <CopyOutlined
+              style={{ fontSize: 20, cursor: "pointer" }}
+              onClick={() =>
+                copy(token.address, () =>
+                  message.success(<span style={{ position: "relative" }}>Copied Contract Address</span>),
+                )
+              }
+            />
+          </div>
         ) : (
-          <div>Native Token</div>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>Native Token</div>
         )}
       </div>
 

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import { Button } from "antd";
 import { DeleteOutlined } from "@ant-design/icons";
 
+import { copy } from "../helpers/EditorHelper";
+
 export default function TokenDetailedDisplay({
   tokenSettingsHelper,
   token,
@@ -13,16 +15,6 @@ export default function TokenDetailedDisplay({
   const [addressCopied, setAddressCopied] = useState(false);
 
   const tokenLink = network.blockExplorer + "token/" + token.address;
-
-  const copyToClipboard = async text => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setAddressCopied(true);
-      setTimeout(() => setAddressCopied(false), 2000);
-    } catch (err) {
-      console.error("Error in copying text: ", err);
-    }
-  };
 
   return (
     <>
@@ -56,7 +48,7 @@ export default function TokenDetailedDisplay({
             </div>
             <div
               style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
-              onClick={() => copyToClipboard(token.address)}
+              onClick={() => copy(token.address)}
             >
               {addressCopied ? (
                 <img

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -41,7 +41,12 @@ export default function TokenDetailedDisplay({
         {token.hasOwnProperty("address") ? (
           <>
             <div
-              style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
+              style={{
+                cursor: "pointer",
+                color: `var(--link-color)`,
+                fontSize: "15px",
+                marginRight: "7px",
+              }}
               onClick={() => window.open(tokenLink, "_blank")}
             >
               {token.address}

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -35,15 +35,27 @@ export default function TokenDetailedDisplay({
         }}
       >
         {token.hasOwnProperty("address") ? (
-          <div
-            style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
-            onClick={() => window.open(tokenLink, "_blank")}
-          >
-            {token.address}
+          <>
+            <div
+              style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
+              onClick={() => window.open(tokenLink, "_blank")}
+            >
+              {token.address}
 
-            {/* ToDo: A copy button might be better here */}
-            <img src="/open_in_new.svg" alt="open_in_new.svg" style={{ paddingBottom: "0.2em" }} />
-          </div>
+              {/* ToDo: A copy button might be better here - added but still has the link capability */}
+              <img src="/open_in_new.svg" alt="open_in_new.svg" style={{ paddingBottom: "0.2em" }} />
+            </div>
+            <div
+              style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
+              onClick={() => copyToClipboard(token.address)}
+            >
+              <img
+                src="/paste-svgrepo-com.svg"
+                alt="Copy"
+                style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
+              />
+            </div>
+          </>
         ) : (
           <div>Native Token</div>
         )}

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Button } from "antd";
 import { DeleteOutlined } from "@ant-design/icons";
@@ -10,11 +10,15 @@ export default function TokenDetailedDisplay({
   network,
   setItemDetailed,
 }) {
+  const [addressCopied, setAddressCopied] = useState(false);
+
   const tokenLink = network.blockExplorer + "token/" + token.address;
 
   const copyToClipboard = async text => {
     try {
       await navigator.clipboard.writeText(text);
+      setAddressCopied(true);
+      setTimeout(() => setAddressCopied(false), 2000);
     } catch (err) {
       console.error("Error in copying text: ", err);
     }
@@ -49,11 +53,19 @@ export default function TokenDetailedDisplay({
               style={{ cursor: "pointer", color: `var(--link-color)`, fontSize: "15px" }}
               onClick={() => copyToClipboard(token.address)}
             >
-              <img
-                src="/paste-svgrepo-com.svg"
-                alt="Copy"
-                style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
-              />
+              {addressCopied ? (
+                <img
+                  src="/greenCheckmark.svg"
+                  alt="Copy"
+                  style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
+                />
+              ) : (
+                <img
+                  src="/paste-svgrepo-com.svg"
+                  alt="Copy"
+                  style={{ paddingBottom: "0.2em", width: "25px", height: "25px", transform: "scale(1.1)" }}
+                />
+              )}
             </div>
           </>
         ) : (

--- a/packages/react-app/src/components/TokenDetailedDisplay.jsx
+++ b/packages/react-app/src/components/TokenDetailedDisplay.jsx
@@ -12,6 +12,14 @@ export default function TokenDetailedDisplay({
 }) {
   const tokenLink = network.blockExplorer + "token/" + token.address;
 
+  const copyToClipboard = async text => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      console.error("Error in copying text: ", err);
+    }
+  };
+
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>

--- a/packages/react-app/src/helpers/EditorHelper.js
+++ b/packages/react-app/src/helpers/EditorHelper.js
@@ -1,0 +1,23 @@
+export const copy = async (text, message) => {
+  let copySuccessful = false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    copySuccessful = true;
+  } catch (error) {
+    console.error("navigator.clipboard.writeText is not supported by your browser", error);
+  }
+
+  if (!copySuccessful) {
+    const el = document.createElement("textarea");
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  }
+
+  if (message) {
+    message();
+  }
+};


### PR DESCRIPTION
It looks like we rewrote the whole app, but actually most of the changed lines were created with the prettier tool, e.g. files where 4 spaces were used for indentation now use the react standard 2 spaces, but git shows these as changed lines.

The goal of this PR was to create a copy button on the token detailed view, so we can easily copy the contract address.
There were 3 places where we had the copy function, so I created a helper class, to avoid code duplication.


https://github.com/scaffold-eth/punk-wallet/assets/1397179/05deff98-f173-4144-bb43-9a1283cda9f6



Cheers,
Tamas