### PR TITLE
punkwallet.io/address:ethAmount:networkName

### DIFF
--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -32,12 +32,13 @@ const { utils } = require("ethers");
 */
 
 export default function EtherInput(props) {
-  const [mode, setMode] = useState(props.price ? "USD" : props.token);
-  const [display, setDisplay] = useState();
+  const [mode, setMode] = useState(props.ethMode ? props.token : (props.price ? "USD" : props.token));
   const [value, setValue] = useState();
   const [displayMax, setDisplayMax] = useState();
 
   const currentValue = typeof props.value !== "undefined" ? props.value : value;
+
+  const [display, setDisplay] = useState(currentValue);
 
   const balance = useBalance(props.provider, props.address, 1000);
   let floatBalance = parseFloat("0.00");


### PR DESCRIPTION
This PR should make it possible to put the networkName?:address:ethAmount?
(network matches if any network names startsWith the incoming name)

For simplicity, if there is an amount specified, the token selector switches back to the native token.

**Note:**
On localhost I always had to create a new tab, otherwise the app froze. This happened before my changes as well, but punkwallet.io works properly.

http://localhost:3000/bas:0xc54C244200d657650087455869f1aD168537d3B3:0.004


https://github.com/scaffold-eth/punk-wallet/assets/1397179/294e3a6a-dc18-4b72-834a-4c9185ec04ba

