### PR TITLE
On Polygon, I wanted to use ethers for EIP-1559, but when implementin…

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -53,8 +53,6 @@ import {
   onSessionProposal,
 } from "./helpers/WalletConnectV2Helper";
 
-import { sendTransaction } from "./helpers/EIP1559Helper";
-
 import {
   ON_CHAIN_IBAN_VALUE,
   getAvailableTargetChainNames,

--- a/packages/react-app/src/helpers/EIP1559Helper.js
+++ b/packages/react-app/src/helpers/EIP1559Helper.js
@@ -41,7 +41,7 @@ export const createEthersWallet = ethersProvider => {
 
 // Create EIP-1559 type-2 transactions on mainnet and polygon
 // Other networks use legacy transactions with gasPrice
-export const sendTransaction = (txParams, signer, injectedProvider) => {
+export const sendTransaction = (txParams, signer, injectedProvider, relayerWallet) => {
   const chainId = getChainIdNumber(txParams);
 
   let result;
@@ -62,7 +62,7 @@ export const sendTransaction = (txParams, signer, injectedProvider) => {
   if (chainId == NETWORKS.ethereum.chainId) {
     return sendTransactionMainnet(txParams);
   } else if (chainId == NETWORKS.polygon.chainId) {
-    return sendTransactionPolygon(txParams, signer);
+    return sendTransactionPolygon(txParams, relayerWallet);
   }
 };
 

--- a/packages/react-app/src/helpers/PolygonRelayerAccountHelper.js
+++ b/packages/react-app/src/helpers/PolygonRelayerAccountHelper.js
@@ -7,7 +7,7 @@ const RELAYER_PK = process.env.REACT_APP_RELAYER_PK;
 export const sendTransactionViaRelayerAccount = async (txParams, origin, provider) => {
 	const relayerWallet = new ethers.Wallet(RELAYER_PK, provider);
 
-	const result = await sendTransaction(txParams, relayerWallet);
+	const result = await sendTransaction(txParams, undefined, undefined, relayerWallet);
 
 	result.origin = origin;
 


### PR DESCRIPTION
…g gasless transactions, I broke it. This small fix ensures that either the relayerWallet used for gasless txs, or an ethers wallet with the local storage private key is created for EIP-1559.

On Polygon, ethers wallet was used for EIP-1559. (Mainnet and Polygon uses ethers wallet, other networks use the "old" [BurnerProvider](https://www.npmjs.com/package/burner-provider))
Later I broke this, when implementing gasLess transactions, where a relayer ethers wallet is used to send the transactions.

This fix should combine the two: 
- When sending DAI or USDT, an ethers wallet is created with the relayer private key
- When sending something else, e.g. Matic, an ethers wallet is created from the local storage private key

https://github.com/scaffold-eth/punk-wallet/assets/1397179/e1b65878-ffd5-4ee4-9368-adfce167d23d

