### PR TITLE
Default alchemy api key for testing

### DIFF
--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -1,4 +1,6 @@
-const ALCHEMY_API_KEY_MAINNET = process.env.REACT_APP_ALCHEMY_API_KEY_MAINNET;
+const TAMS_FREE_ALCHEMY_API_KEY = "7OQ7KlD3Ldrw_Zhvh8_RhkJRf1lm9s90";
+
+const ALCHEMY_API_KEY_MAINNET = process.env.REACT_APP_ALCHEMY_API_KEY_MAINNET ?? TAMS_FREE_ALCHEMY_API_KEY;
 
 // MY INFURA_ID, SWAP IN YOURS FROM https://infura.io/dashboard/ethereum
 export const INFURA_ID = "5b3aa68d82264f59bb6a1874cb3c23ea"; // trying the  emoji.support key


### PR DESCRIPTION
If someone doesn't have REACT_APP_ALCHEMY_API_KEY_MAINNET set in the .env file, a noNetwork error is thrown.

I've added a default Alchemy API key to fix this.

<img width="1512" alt="Screenshot 2024-01-30 at 12 27 16" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/309ecfa5-ef02-4dab-8ef0-e68b14916968">

