### PR TITLE
Network switch before PK

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -846,7 +846,13 @@ function App(props) {
             networkSettingsHelper.updateSelectedName(incomingNetwork.name);
             setTargetNetwork(networkSettingsHelper.getSelectedItem(true));
 
-            window.history.pushState({}, "", "/");
+            let pushStateURL = "/"
+
+            if ((incomingParts.length > 1) && incomingParts[1] == "pk") {
+              pushStateURL = "pk" + window.location.hash;
+            }
+
+            window.history.pushState({}, "", pushStateURL);
             pushState = true;
 
             index++;


### PR DESCRIPTION
This PR is for switching to a specific network before handling the PK from the URL:

e.g.:
http://localhost:3000/opt:pk#0x0ee1eb047593392b63602f476d0f7f6f82ca42520cf5f5e88bf8c8128b27b51b

This will switch to optimism and then get the punk with the PK.


https://github.com/scaffold-eth/punk-wallet/assets/1397179/826533f9-c4df-45a5-8e83-7367ee53b543



