### PR TITLE
Do not display network settings for localhost and buidlguidl

### DIFF
--- a/packages/react-app/src/components/SettingsModal.jsx
+++ b/packages/react-app/src/components/SettingsModal.jsx
@@ -114,6 +114,8 @@ const ItemWithButtons = ({item, itemCoreDisplay, itemDetailedDisplay, setItemDet
 
     const isCurrentlySelected = selectedItem ? (selectedItem.name == item.name) : (itemIndex == 0);
 
+    const isItemDetailedDisplay = itemDetailedDisplay && ((item?.name !== "localhost") && (item?.name !== "buidlguidl"));
+
     return (
         <div style={{ display: "flex", alignItems: "center"}}>
             <div style={{ flexGrow:3, display: "flex", justifyContent: "space-around", alignItems:"center", padding:"0.25em"}}>
@@ -127,7 +129,7 @@ const ItemWithButtons = ({item, itemCoreDisplay, itemDetailedDisplay, setItemDet
                 <ItemDisplay
                     item={item}
                     itemCoreDisplay={itemCoreDisplay}
-                    onClick={itemDetailedDisplay ? () => setItemDetailed(item) : undefined}
+                    onClick={isItemDetailedDisplay ? () => setItemDetailed(item) : undefined}
                     isCurrentlySelected={isCurrentlySelected}
                     width={"7em"} // ToDo: There should be a better way to align the buttons
                 />


### PR DESCRIPTION
This is a small fix which prevents us to click on localhost and buidlguidl, where we don't really have settings to display.

<img width="1512" alt="Screenshot 2024-03-21 at 17 19 36" src="https://github.com/scaffold-eth/punk-wallet/assets/1397179/10751cbd-012d-482a-91fe-9283e2e02ac6">
