### PR TITLE
EIP-681 QR and Payment Link

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -25,6 +25,7 @@
     "apollo-client": "^2.6.10",
     "apollo-utilities": "^1.3.4",
     "axios": "^0.20.0",
+    "bignumber.js": "^9.1.2",
     "bnc-notify": "^1.5.0",
     "burner-provider": "^1.0.38",
     "dotenv": "^8.2.0",

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -195,12 +195,15 @@ function App(props) {
     : undefined;
 
   const switchToEth = localStorage.getItem("switchToEth");
-  localStorage.removeItem("switchToEth");
 
-  if (selectedErc20Token && switchToEth) {
-    if (targetNetwork?.nativeToken?.name) {
-      tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
-      console.log("Switched to native token");
+  if (switchToEth) {
+    localStorage.removeItem("switchToEth");
+
+    if (selectedErc20Token) {
+      if (targetNetwork?.nativeToken?.name) {
+        tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
+        console.log("Switched to native token");
+      }
     }
   }
 
@@ -833,11 +836,13 @@ function App(props) {
   const [priceERC20, setPriceERC20] = useState();
 
   const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
-  localStorage.removeItem("switchToTokenAddress");
 
   if (switchToTokenAddress) {
+    localStorage.removeItem("switchToTokenAddress");
     const storedAmount = localStorage.getItem("amount");
-    localStorage.removeItem("amount");
+    if (storedAmount) {
+      localStorage.removeItem("amount");
+    }
 
     let tokens = targetNetwork?.erc20Tokens;
 
@@ -867,9 +872,10 @@ function App(props) {
   }
 
   const storedAmount = localStorage.getItem("amount");
-  localStorage.removeItem("amount");
 
   if (storedAmount) {
+    localStorage.removeItem("amount");
+
     const amountBigNumber = BigNumber.from(storedAmount);
     setAmount(amountBigNumber);
   }

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -853,13 +853,12 @@ function App(props) {
         tokens = tokens.concat(customTokens);
       }
 
-      const token = tokens.find(token => token.address == switchToTokenAddress);
+      const token = tokens.find(token => token.address.toLowerCase() === switchToTokenAddress.toLowerCase());
 
       if (token) {
         tokenSettingsHelper.updateSelectedName(token.name);
 
         if (storedAmount) {
-          console.log("Amount to set", storedAmount);
           const amountBigNumber = BigNumber.from(storedAmount);
           setAmount(amountBigNumber);
         }
@@ -870,10 +869,12 @@ function App(props) {
   }
 
   const storedAmount = localStorage.getItem("amount");
-  localStorage.removeItem("amount");
 
   if (storedAmount) {
+    localStorage.removeItem("amount");
+
     setAmountEthMode(true);
+
     const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(storedAmount));
     setAmount(decimalCorrectedAmount);
   }

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -841,6 +841,9 @@ function App(props) {
   if (switchToTokenAddress) {
     localStorage.removeItem("switchToTokenAddress");
 
+    const storedAmount = localStorage.getItem("amount");
+    localStorage.removeItem("amount");
+
     let tokens = targetNetwork?.erc20Tokens;
 
     if (tokens) {
@@ -855,11 +858,9 @@ function App(props) {
       if (token) {
         tokenSettingsHelper.updateSelectedName(token.name);
 
-        const amount = localStorage.getItem("amount");
-
-        if (amount) {
-          console.log("Amount to set", amount);
-          const amountBigNumber = BigNumber.from(amount);
+        if (storedAmount) {
+          console.log("Amount to set", storedAmount);
+          const amountBigNumber = BigNumber.from(storedAmount);
           setAmount(amountBigNumber);
         }
       } else {
@@ -868,7 +869,14 @@ function App(props) {
     }
   }
 
+  const storedAmount = localStorage.getItem("amount");
   localStorage.removeItem("amount");
+
+  if (storedAmount) {
+    setAmountEthMode(true);
+    const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(storedAmount));
+    setAmount(decimalCorrectedAmount);
+  }
 
   if (window.location.pathname !== "/") {
     try {
@@ -1284,6 +1292,7 @@ function App(props) {
                 setAmount(value);
               }}
               receiveMode={receiveMode}
+              amount={amount}
             />
           )}
         </div>

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1249,7 +1249,6 @@ function App(props) {
             <Input disabled={true} value={amount} />
           ) : selectedErc20Token ? (
             <ERC20Input
-              key={`${amount}_${selectedErc20Token}_${priceERC20}`}
               token={selectedErc20Token}
               value={amount}
               amount={amount}
@@ -1263,7 +1262,6 @@ function App(props) {
             />
           ) : (
             <EtherInput
-              key={amount}
               price={price || targetNetwork.price}
               value={amount}
               token={targetNetwork.token || "ETH"}

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -887,7 +887,7 @@ function App(props) {
       if (path.startsWith("ethereum:")) {
         const eip681URL = window.location.href.substring(window.location.href.indexOf("ethereum:"));
 
-        parseEIP618(eip681URL, networkSettingsHelper, setTargetNetwork, setToAddress);
+        parseEIP618(eip681URL, networkSettingsHelper, setTargetNetwork, setToAddress, setAmount);
       }
 
       window.history.pushState({}, "", "/");

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -773,12 +773,6 @@ function App(props) {
         </div>
       );
     }
-  } else {
-    networkDisplay = (
-      <div style={{ zIndex: -1, position: "absolute", right: 154, top: 28, padding: 16, color: targetNetwork.color }}>
-        {networkName}
-      </div>
-    );
   }
 
   const loadWeb3Modal = useCallback(async () => {

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -835,6 +835,11 @@ function App(props) {
 
   const [receiveMode, setReceiveMode] = useState(false);
 
+  // ERC20 Token balance to use in ERC20Balance and in ERC20Input
+  const [balanceERC20, setBalanceERC20] = useState(null);
+
+  const [priceERC20, setPriceERC20] = useState();
+
   const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
 
   if (switchToTokenAddress) {
@@ -855,6 +860,7 @@ function App(props) {
       const token = tokens.find(token => token.address.toLowerCase() === switchToTokenAddress.toLowerCase());
 
       if (token) {
+        setPriceERC20(undefined);
         tokenSettingsHelper.updateSelectedName(token.name);
 
         if (storedAmount) {
@@ -988,11 +994,6 @@ function App(props) {
 
   const [depositing, setDepositing] = useState();
   const [depositAmount, setDepositAmount] = useState();
-
-  // ERC20 Token balance to use in ERC20Balance and in ERC20Input
-  const [balanceERC20, setBalanceERC20] = useState(null);
-
-  const [priceERC20, setPriceERC20] = useState();
 
   const walletDisplay =
     web3Modal && web3Modal.cachedProvider ? (

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -866,12 +866,6 @@ function App(props) {
     }
   }
 
-  useEffect(() => {
-    if (!switchToEth && !switchToTokenAddress) {
-      setAmount("");
-    }
-  }, [targetNetwork, selectedErc20Token]);
-
   const storedAmount = localStorage.getItem("amount");
   localStorage.removeItem("amount");
 
@@ -1289,6 +1283,8 @@ function App(props) {
               }}
               receiveMode={receiveMode}
               amount={amount}
+              selectedErc20Token={selectedErc20Token}
+              targetNetwork={targetNetwork}
             />
           )}
         </div>

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -857,8 +857,10 @@ function App(props) {
       const token = tokens.find(token => token.address.toLowerCase() === switchToTokenAddress.toLowerCase());
 
       if (token) {
-        setPriceERC20(undefined);
-        tokenSettingsHelper.updateSelectedName(token.name);
+        if (selectedErc20Token?.address.toLowerCase() !== switchToTokenAddress.toLowerCase()) {
+          setPriceERC20(undefined);
+          tokenSettingsHelper.updateSelectedName(token.name);
+        }
 
         if (storedAmount) {
           const amountBigNumber = BigNumber.from(storedAmount);

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -194,11 +194,11 @@ function App(props) {
       )
     : undefined;
 
-  if (selectedErc20Token) {
-    const switchToEth = localStorage.getItem("switchToEth");
-    if (switchToEth) {
-      localStorage.removeItem("switchToEth");
+  const switchToEth = localStorage.getItem("switchToEth");
+  localStorage.removeItem("switchToEth");
 
+  if (selectedErc20Token) {
+    if (switchToEth) {
       if (targetNetwork?.nativeToken?.name) {
         tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
         console.log("Switched to native token");
@@ -824,10 +824,6 @@ function App(props) {
 
   const [amount, setAmount] = useState();
 
-  useEffect(() => {
-    setAmount("")
-  }, [targetNetwork, selectedErc20Token]);
-
   const [amountEthMode, setAmountEthMode] = useState(false);
 
   const [receiveMode, setReceiveMode] = useState(false);
@@ -871,6 +867,12 @@ function App(props) {
       }
     }
   }
+
+  useEffect(() => {
+    if (!switchToEth && !switchToTokenAddress) {
+      setAmount("");
+    }
+  }, [targetNetwork, selectedErc20Token]);
 
   const storedAmount = localStorage.getItem("amount");
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -856,8 +856,9 @@ function App(props) {
       const token = tokens.find(token => token.address.toLowerCase() === switchToTokenAddress.toLowerCase());
 
       if (token) {
+        setPriceERC20(undefined);
+
         if (selectedErc20Token?.address.toLowerCase() !== switchToTokenAddress.toLowerCase()) {
-          setPriceERC20(undefined);
           tokenSettingsHelper.updateSelectedName(token.name);
         }
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -198,7 +198,6 @@ function App(props) {
     : undefined;
 
   const switchToEth = localStorage.getItem("switchToEth");
-  console.log("switchToEth", switchToEth);
 
   if (switchToEth) {
     if (targetNetwork?.nativeToken?.name) {
@@ -826,7 +825,6 @@ function App(props) {
   const [toAddress, setToAddress] = useLocalStorage("punkWalletToAddress", "", 120000);
 
   const [amount, setAmount] = useState();
-  console.log("amount", amount);
 
   const [amountEthMode, setAmountEthMode] = useState(false);
 
@@ -836,7 +834,6 @@ function App(props) {
   const [balanceERC20, setBalanceERC20] = useState(null);
 
   const [priceERC20, setPriceERC20] = useState();
-  console.log("priceERC20", priceERC20);
 
   const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -197,12 +197,10 @@ function App(props) {
   const switchToEth = localStorage.getItem("switchToEth");
   localStorage.removeItem("switchToEth");
 
-  if (selectedErc20Token) {
-    if (switchToEth) {
-      if (targetNetwork?.nativeToken?.name) {
-        tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
-        console.log("Switched to native token");
-      }
+  if (selectedErc20Token && switchToEth) {
+    if (targetNetwork?.nativeToken?.name) {
+      tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
+      console.log("Switched to native token");
     }
   }
 
@@ -823,6 +821,7 @@ function App(props) {
   const [toAddress, setToAddress] = useLocalStorage("punkWalletToAddress", "", 120000);
 
   const [amount, setAmount] = useState();
+  console.log("amount", amount);
 
   const [amountEthMode, setAmountEthMode] = useState(false);
 
@@ -834,10 +833,9 @@ function App(props) {
   const [priceERC20, setPriceERC20] = useState();
 
   const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
+  localStorage.removeItem("switchToTokenAddress");
 
   if (switchToTokenAddress) {
-    localStorage.removeItem("switchToTokenAddress");
-
     const storedAmount = localStorage.getItem("amount");
     localStorage.removeItem("amount");
 
@@ -875,17 +873,11 @@ function App(props) {
   }, [targetNetwork, selectedErc20Token]);
 
   const storedAmount = localStorage.getItem("amount");
+  localStorage.removeItem("amount");
 
   if (storedAmount) {
-    localStorage.removeItem("amount");
-
-    setAmountEthMode(true);
-
     const amountBigNumber = BigNumber.from(storedAmount);
     setAmount(amountBigNumber);
-
-    //const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(storedAmount));
-    //setAmount(decimalCorrectedAmount);
   }
 
   if (window.location.pathname !== "/") {

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -833,6 +833,7 @@ function App(props) {
   const [balanceERC20, setBalanceERC20] = useState(null);
 
   const [priceERC20, setPriceERC20] = useState();
+  console.log("priceERC20", priceERC20);
 
   const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
 
@@ -855,7 +856,7 @@ function App(props) {
       const token = tokens.find(token => token.address.toLowerCase() === switchToTokenAddress.toLowerCase());
 
       if (token) {
-        setPriceERC20(undefined);
+        setPriceERC20(null);
 
         if (selectedErc20Token?.address.toLowerCase() !== switchToTokenAddress.toLowerCase()) {
           tokenSettingsHelper.updateSelectedName(token.name);

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1,13 +1,12 @@
-import { CaretUpOutlined, ScanOutlined, SendOutlined, HistoryOutlined } from "@ant-design/icons";
+import { CaretUpOutlined, ScanOutlined, SendOutlined } from "@ant-design/icons";
 import { StaticJsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { formatEther, parseEther } from "@ethersproject/units";
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import { Alert, Button, Checkbox, Col, Row, Select, Spin, Switch, Input, Modal, notification } from "antd";
+import { Alert, Button, Col, Row, Spin, Switch, Input, Modal } from "antd";
 import "antd/dist/antd.css";
 import { useUserAddress } from "eth-hooks";
 import React, { useCallback, useEffect, useState, useMemo } from "react";
 import Web3Modal from "web3modal";
-import { parse } from "eth-url-parser";
 import "./App.css";
 import {
   Account,

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -823,7 +823,10 @@ function App(props) {
   const [toAddress, setToAddress] = useLocalStorage("punkWalletToAddress", "", 120000);
 
   const [amount, setAmount] = useState();
-  console.log("amount", amount, typeof amount === 'string');
+
+  useEffect(() => {
+    setAmount("")
+  }, [targetNetwork, selectedErc20Token]);
 
   const [amountEthMode, setAmountEthMode] = useState(false);
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -38,7 +38,8 @@ import {
   WalletConnectTransactionPopUp,
   WalletConnectV2ConnectionError,
 } from "./components";
-import { INFURA_ID, NETWORK, NETWORKS } from "./constants";
+import showModal from "./components/GenericModal";
+import { INFURA_ID, NETWORK, NETWORKS, ERROR_MESSAGES } from "./constants";
 import { Transactor } from "./helpers";
 import { parseEIP618 } from "./helpers/EIP618Helper";
 import { useBalance, useExchangePrice, useGasPrice, useLocalStorage, usePoller, useUserProvider } from "./hooks";
@@ -84,6 +85,8 @@ import {
   getTokens,
   migrateSelectedTokenStorageSetting,
 } from "./helpers/TokenSettingsHelper";
+
+const { TOKEN_ERROR } = ERROR_MESSAGES;
 
 const { confirm } = Modal;
 
@@ -867,7 +870,7 @@ function App(props) {
           setAmount(amountBigNumber);
         }
       } else {
-        // error screen that token is not supported
+        showModal(TOKEN_ERROR.NOT_SUPPORTED + " :" + switchToTokenAddress);
       }
     }
   }

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -829,7 +829,7 @@ function App(props) {
   const [toAddress, setToAddress] = useLocalStorage("punkWalletToAddress", "", 120000);
 
   const [amount, setAmount] = useState();
-  console.log("amount", amount);
+  console.log("amount", amount, typeof amount === 'string');
 
   const [amountEthMode, setAmountEthMode] = useState(false);
 
@@ -880,8 +880,11 @@ function App(props) {
 
     setAmountEthMode(true);
 
-    const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(storedAmount));
-    setAmount(decimalCorrectedAmount);
+    const amountBigNumber = BigNumber.from(storedAmount);
+    setAmount(amountBigNumber);
+
+    //const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(storedAmount));
+    //setAmount(decimalCorrectedAmount);
   }
 
   if (window.location.pathname !== "/") {

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1247,7 +1247,6 @@ function App(props) {
                   isMoneriumTransferReady={isMoneriumTransferReady}
                   ibanAddressObject={ibanAddressObject}
                   setIbanAddressObject={setIbanAddressObject}
-                  setAmountEthMode={setAmountEthMode}
                   networkSettingsHelper={networkSettingsHelper}
                   setTargetNetwork={setTargetNetwork}
                   walletConnect={async wcLink => {

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -88,7 +88,7 @@ import {
 
 const { confirm } = Modal;
 
-const { ethers } = require("ethers");
+const { ethers, BigNumber } = require("ethers");
 
 const { OrderState } = require("@monerium/sdk");
 
@@ -203,30 +203,6 @@ function App(props) {
       if (targetNetwork?.nativeToken?.name) {
         tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
         console.log("Switched to native token");
-      }
-    }
-  }
-
-  const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
-
-  if (switchToTokenAddress) {
-    localStorage.removeItem("switchToTokenAddress");
-
-    let tokens = targetNetwork?.erc20Tokens;
-
-    if (tokens) {
-      const customTokens = tokenSettingsHelper.getCustomItems();
-
-      if (customTokens.length > 0) {
-        tokens = tokens.concat(customTokens);
-      }
-
-      const token = tokens.find(token => token.address == switchToTokenAddress);
-
-      if (token) {
-        tokenSettingsHelper.updateSelectedName(token.name);
-      } else {
-        // error screen that token is not supported
       }
     }
   }
@@ -854,10 +830,45 @@ function App(props) {
   const [toAddress, setToAddress] = useLocalStorage("punkWalletToAddress", "", 120000);
 
   const [amount, setAmount] = useState();
+  console.log("amount", amount);
 
   const [amountEthMode, setAmountEthMode] = useState(false);
 
   const [receiveMode, setReceiveMode] = useState(false);
+
+  const switchToTokenAddress = localStorage.getItem("switchToTokenAddress");
+
+  if (switchToTokenAddress) {
+    localStorage.removeItem("switchToTokenAddress");
+
+    let tokens = targetNetwork?.erc20Tokens;
+
+    if (tokens) {
+      const customTokens = tokenSettingsHelper.getCustomItems();
+
+      if (customTokens.length > 0) {
+        tokens = tokens.concat(customTokens);
+      }
+
+      const token = tokens.find(token => token.address == switchToTokenAddress);
+
+      if (token) {
+        tokenSettingsHelper.updateSelectedName(token.name);
+
+        const amount = localStorage.getItem("amount");
+
+        if (amount) {
+          console.log("Amount to set", amount);
+          const amountBigNumber = BigNumber.from(amount);
+          setAmount(amountBigNumber);
+        }
+      } else {
+        // error screen that token is not supported
+      }
+    }
+  }
+
+  localStorage.removeItem("amount");
 
   if (window.location.pathname !== "/") {
     try {

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -195,16 +195,15 @@ function App(props) {
     : undefined;
 
   const switchToEth = localStorage.getItem("switchToEth");
+  console.log("switchToEth", switchToEth);
 
   if (switchToEth) {
-    localStorage.removeItem("switchToEth");
-
-    if (selectedErc20Token) {
-      if (targetNetwork?.nativeToken?.name) {
-        tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
-        console.log("Switched to native token");
-      }
+    if (targetNetwork?.nativeToken?.name) {
+      tokenSettingsHelper.updateSelectedName(targetNetwork.nativeToken.name);
+      console.log("Switched to native token");
     }
+
+    localStorage.removeItem("switchToEth");
   }
 
   const mainnetProvider = new StaticJsonRpcProvider(NETWORKS.ethereum.rpcUrl);

--- a/packages/react-app/src/components/AddressInput.jsx
+++ b/packages/react-app/src/components/AddressInput.jsx
@@ -3,13 +3,10 @@ import { Badge, Input, message, Spin } from "antd";
 import { useLookupAddress } from "eth-hooks";
 import React, { useCallback, useState, useEffect } from "react";
 import QrReader from "react-qr-reader-es6";
-import { BigNumber } from "ethers";
-import { formatEther } from "ethers/lib/utils";
-import { parse } from "eth-url-parser";
 import { QRPunkBlockie } from ".";
 
 import { isValidIban } from "../helpers/MoneriumHelper";
-import { handleNetworkByQR } from "../helpers/EIP618Helper";
+import { parseEIP618 } from "../helpers/EIP618Helper";
 
 // probably we need to change value={toAddress} to address={toAddress}
 
@@ -65,7 +62,6 @@ export default function AddressInput(props) {
     ibanAddressObject,
     setIbanAddressObject,
     isMoneriumTransferReady,
-    setAmountEthMode,
     setTargetNetwork,
     networkSettingsHelper,
   } = props;
@@ -271,39 +267,26 @@ export default function AddressInput(props) {
               updateAddress();
             } else {
               let possibleNewValue = newValue;
-              let amount;
-              const eip681Object = parse(possibleNewValue);
-              const tokenAddress = eip681Object?.target_address;
 
-              // token transfer
-              if (possibleNewValue.includes("transfer") || possibleNewValue.includes("uint256")) {
-                console.log("TOKEN TRANSFER");
-                const chainId = eip681Object.chain_id;
-                const tokenAmount = eip681Object.parameters.uint256;
-                localStorage.setItem("switchToTokenAddress", tokenAddress);
-                setAmountEthMode(true);
-                amount = parseInt(tokenAmount);
-
-                handleNetworkByQR(chainId, networkSettingsHelper, setTargetNetwork);
-              } else if (possibleNewValue.includes("?")) {
-                amount = eip681Object.parameters.value;
-
-                amount = BigNumber.from(parseFloat(amount).toString());
-                amount = formatEther(amount);
-                amount = Math.round(amount);
-                setAmountEthMode(true);
-                localStorage.setItem("switchToEth", true);
-
-                console.log("eth amount: ", amount);
+              try {
+                if (possibleNewValue.startsWith("ethereum:")) {
+                  parseEIP618(possibleNewValue, networkSettingsHelper, setTargetNetwork, setToAddress);
+                  setScan(false);
+                  return;
+                }
+              } catch (error) {
+                console.log("Coudn't parse EIP681", error);
               }
 
+              possibleNewValue = possibleNewValue.replace("ethereum:", "");
+              possibleNewValue = possibleNewValue.replace("eth:", "");
+              console.log("possibleNewValue",possibleNewValue)
               if (possibleNewValue.indexOf("/") >= 0) {
                 possibleNewValue = possibleNewValue.substr(possibleNewValue.lastIndexOf("0x"));
                 console.log("CLEANED VALUE", possibleNewValue);
               }
               setScan(false);
-              updateAddress(eip681Object.target_address);
-              setAmount(amount);
+              updateAddress(possibleNewValue);
             }
           }
         }}

--- a/packages/react-app/src/components/AddressInput.jsx
+++ b/packages/react-app/src/components/AddressInput.jsx
@@ -270,7 +270,7 @@ export default function AddressInput(props) {
 
               try {
                 if (possibleNewValue.startsWith("ethereum:")) {
-                  parseEIP618(possibleNewValue, networkSettingsHelper, setTargetNetwork, setToAddress);
+                  parseEIP618(possibleNewValue, networkSettingsHelper, setTargetNetwork, setToAddress, setAmount);
                   setScan(false);
                   return;
                 }

--- a/packages/react-app/src/components/ERC20Balance.jsx
+++ b/packages/react-app/src/components/ERC20Balance.jsx
@@ -62,12 +62,16 @@ export default function ERC20Balance({
   // https://medium.com/doctolib/react-stop-checking-if-your-component-is-mounted-3bb2568a4934
 
   useEffect(() => {
+    if (price === 0 || price !== undefined) {
+      return;
+    }
+
     async function getPrice() {
       setPrice(await getTokenPrice(targetNetwork.chainId, token.address));
     }
 
     getPrice();
-  }, [targetNetwork, token]);
+  }, [targetNetwork, token, price]);
 
   useEffect(() => {
     async function getBalance() {

--- a/packages/react-app/src/components/ERC20Balance.jsx
+++ b/packages/react-app/src/components/ERC20Balance.jsx
@@ -62,7 +62,7 @@ export default function ERC20Balance({
   // https://medium.com/doctolib/react-stop-checking-if-your-component-is-mounted-3bb2568a4934
 
   useEffect(() => {
-    if (price === 0 || price !== undefined) {
+    if (price === 0) {
       return;
     }
 
@@ -71,7 +71,19 @@ export default function ERC20Balance({
     }
 
     getPrice();
-  }, [targetNetwork, token, price]);
+  }, [targetNetwork, token]);
+
+  useEffect(() => {
+    if (price !== null) {
+      return;
+    }
+
+    async function getPrice() {
+      setPrice(await getTokenPrice(targetNetwork.chainId, token.address));
+    }
+
+    getPrice();
+  }, [price]);
 
   useEffect(() => {
     async function getBalance() {

--- a/packages/react-app/src/components/ERC20Input.jsx
+++ b/packages/react-app/src/components/ERC20Input.jsx
@@ -157,7 +157,12 @@ export default function ERC20Input({
         prefix={<Prefix dollarMode={dollarMode} token={token} />}
         addonAfter={<AmountDollarSwitch token={token} dollarMode={dollarMode} setDollarMode={setDollarMode} />}
         onChange={async e => {
-          setUserValue(e.target.value);
+          if (e.target.value === "") {
+            resetValues(setUserValue, setDisplayValue, setAmount);
+          }
+          else {
+            setUserValue(e.target.value);
+          }
         }}
       />
     </div>

--- a/packages/react-app/src/components/ERC20Input.jsx
+++ b/packages/react-app/src/components/ERC20Input.jsx
@@ -7,7 +7,7 @@ import TokenDisplay from "./TokenDisplay";
 
 import { getDisplayNumberWithDecimals, getInverseDecimalCorrectedAmountNumber } from "../helpers/ERC20Helper";
 
-const { ethers } = require("ethers");
+const { ethers, BigNumber } = require("ethers");
 
 // ToDo: add check if enough balance is available, otherwise don't allow user to send
 // ToDo: address check if valid
@@ -112,6 +112,17 @@ export default function ERC20Input({
     // setAmount("");
     if (typeof amount === "string" && amount.length === 0) {
       resetValues(setUserValue, setDisplayValue, setAmount);
+    }
+
+    if (typeof amount === "object") {
+      console.log("amount is a big number", amount.toString());
+      setDollarMode(false);
+
+      const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(amount, token.decimals));
+
+      setAmount(decimalCorrectedAmount);
+      setDisplayValue(decimalCorrectedAmount);
+      
     }
   }, [amount]);
 

--- a/packages/react-app/src/components/ERC20Input.jsx
+++ b/packages/react-app/src/components/ERC20Input.jsx
@@ -97,7 +97,7 @@ export default function ERC20Input({
   }, [userValue]);
 
   useEffect(() => {
-    if (!amount || !price) {
+    if (!amount || !price || typeof amount === "object") {
       return;
     }
 

--- a/packages/react-app/src/components/ERC20Input.jsx
+++ b/packages/react-app/src/components/ERC20Input.jsx
@@ -7,7 +7,7 @@ import TokenDisplay from "./TokenDisplay";
 
 import { getDisplayNumberWithDecimals, getInverseDecimalCorrectedAmountNumber } from "../helpers/ERC20Helper";
 
-const { ethers, BigNumber } = require("ethers");
+const { ethers } = require("ethers");
 
 // ToDo: add check if enough balance is available, otherwise don't allow user to send
 // ToDo: address check if valid

--- a/packages/react-app/src/components/ERC20Input.jsx
+++ b/packages/react-app/src/components/ERC20Input.jsx
@@ -74,6 +74,8 @@ export default function ERC20Input({
   const [userValue, setUserValue] = useState();
   const [displayValue, setDisplayValue] = useState();
 
+  const [tempAmount, setTempAmount] = useState();
+
   useEffect(() => {
     if (userValue === 0 || userValue === undefined) {
       return;
@@ -115,16 +117,22 @@ export default function ERC20Input({
     }
 
     if (typeof amount === "object") {
-      console.log("amount is a big number", amount.toString());
-      setDollarMode(false);
-
       const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(amount, token.decimals));
 
       setAmount(decimalCorrectedAmount);
-      setDisplayValue(decimalCorrectedAmount);
-      
+      setTempAmount(decimalCorrectedAmount);
     }
   }, [amount]);
+
+  useEffect(() => {
+    if (!tempAmount || !price) {
+      return;
+    }
+
+    setDisplayValue(calcDisplayValue(token, tempAmount, dollarMode, price));
+    setTempAmount(undefined);
+
+  }, [tempAmount, price]);
 
   return (
     <div>

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -3,8 +3,6 @@ import React, { useEffect, useState } from "react";
 import { useBalance } from "eth-hooks";
 const { ethers } = require("ethers");
 
-const { utils } = require("ethers");
-
 // small change in useEffect, display currentValue if it's provided by user
 
 /*
@@ -73,7 +71,7 @@ export default function EtherInput(props) {
       gasCost = (parseInt(props.gasPrice, 10) * 150000) / 10 ** 18;
     }
 
-    const etherBalance = utils.formatEther(usingBalance);
+    const etherBalance = ethers.utils.formatEther(usingBalance);
     parseFloat(etherBalance).toFixed(2);
     floatBalance = parseFloat(etherBalance - gasCost);
     if (floatBalance < 0) {

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -44,10 +44,8 @@ export default function EtherInput(props) {
   const [displayMax, setDisplayMax] = useState();
 
   const currentValue = typeof props.value !== "undefined" ? props.value : value;
-  console.log("currentValue", currentValue);
 
   const [display, setDisplay] = useState(currentValue);
-  console.log("display", display);
 
   useEffect(() => {
     resetValues(setValue, setDisplayMax, setAmount);
@@ -87,8 +85,6 @@ export default function EtherInput(props) {
     if (floatBalance < 0) {
       floatBalance = 0;
     }
-    console.log("xxx etherBalance", etherBalance);
-    console.log("xxx floatBalance", floatBalance);
   }
 
   let displayBalance = floatBalance.toFixed(4);

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -30,12 +30,18 @@ const { ethers } = require("ethers");
   - Control input change by onChange={value => { setAmount(value);}}
 */
 
+const resetValues = (setValue, setDisplayMax, setAmount) => {
+  setValue(undefined);
+  setDisplayMax(undefined);
+  setAmount(undefined);
+};
+
 export default function EtherInput(props) {
+  const setAmount = props.onChange;
+
   const [mode, setMode] = useState(props.ethMode ? props.token : props.price ? "USD" : props.token);
-  console.log("mode", mode);
   const [value, setValue] = useState();
   const [displayMax, setDisplayMax] = useState();
-  console.log("props.price", props.price);
 
   const currentValue = typeof props.value !== "undefined" ? props.value : value;
   console.log("currentValue", currentValue);
@@ -44,17 +50,21 @@ export default function EtherInput(props) {
   console.log("display", display);
 
   useEffect(() => {
+    resetValues(setValue, setDisplayMax, setAmount);
+  }, [props.selectedErc20Token, props.targetNetwork]);
+
+  useEffect(() => {
     if (typeof props.value === "object") {
       setDisplayMax(false);
       
       const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(props.value));
 
       if (mode !== "USD") {
-        props.onChange(decimalCorrectedAmount);
+        setAmount(decimalCorrectedAmount);
         setDisplay(decimalCorrectedAmount);
       }
       else if (typeof props.price === "number") {
-        props.onChange(decimalCorrectedAmount);
+        setAmount(decimalCorrectedAmount);
         setDisplay((decimalCorrectedAmount * props.price).toFixed(2));
       } 
     }
@@ -149,9 +159,7 @@ export default function EtherInput(props) {
           onClick={() => {
             setDisplay(getBalance(mode));
             setDisplayMax(true);
-            if (typeof props.onChange === "function") {
-              props.onChange(floatBalance);
-            }
+            setAmount(floatBalance);
           }}
         >
           max
@@ -168,9 +176,7 @@ export default function EtherInput(props) {
           setDisplayMax(false);
 
           if (e.target.value === "") {
-            if (typeof props.onChange === "function") {
-              props.onChange(undefined);
-            }
+            setAmount(undefined);
           }
 
           if (mode === "USD") {
@@ -178,18 +184,14 @@ export default function EtherInput(props) {
             if (possibleNewValue) {
               const ethValue = possibleNewValue / props.price;
               setValue(ethValue);
-              if (typeof props.onChange === "function") {
-                props.onChange(ethValue);
-              }
+              setAmount(ethValue);
               setDisplay(newValue);
             } else {
               setDisplay(newValue);
             }
           } else {
             setValue(newValue);
-            if (typeof props.onChange === "function") {
-              props.onChange(newValue);
-            }
+            setAmount(newValue);
             setDisplay(newValue);
           }
         }}

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -53,7 +53,7 @@ export default function EtherInput(props) {
 
   useEffect(() => {
     if (typeof props.value === "object") {
-      resetValues(setValue, setDisplayMax, setAmount);
+      setDisplayMax(false);
       
       const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(props.value));
 

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -53,7 +53,7 @@ export default function EtherInput(props) {
 
   useEffect(() => {
     if (typeof props.value === "object") {
-      setDisplayMax(false);
+      resetValues(setValue, setDisplayMax, setAmount);
       
       const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(props.value));
 

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -47,8 +47,11 @@ export default function EtherInput(props) {
 
   const [display, setDisplay] = useState(currentValue);
 
+
   useEffect(() => {
-    resetValues(setValue, setDisplayMax, setAmount);
+    if (typeof props.value !== "object") {
+      resetValues(setValue, setDisplayMax, setAmount);
+    }
   }, [props.selectedErc20Token, props.targetNetwork]);
 
   useEffect(() => {
@@ -165,7 +168,7 @@ export default function EtherInput(props) {
         placeholder={props.placeholder ? props.placeholder : "amount in " + mode}
         autoFocus={props.autoFocus}
         prefix={prefix}
-        value={display}
+        value={typeof props.value !== "object" ? display : ""}
         addonAfter={addonAfter}
         onChange={async e => {
           const newValue = e.target.value;

--- a/packages/react-app/src/components/EtherInput.jsx
+++ b/packages/react-app/src/components/EtherInput.jsx
@@ -1,6 +1,7 @@
 import { Input } from "antd";
 import React, { useEffect, useState } from "react";
 import { useBalance } from "eth-hooks";
+const { ethers } = require("ethers");
 
 const { utils } = require("ethers");
 
@@ -33,12 +34,33 @@ const { utils } = require("ethers");
 
 export default function EtherInput(props) {
   const [mode, setMode] = useState(props.ethMode ? props.token : props.price ? "USD" : props.token);
+  console.log("mode", mode);
   const [value, setValue] = useState();
   const [displayMax, setDisplayMax] = useState();
+  console.log("props.price", props.price);
 
   const currentValue = typeof props.value !== "undefined" ? props.value : value;
+  console.log("currentValue", currentValue);
 
   const [display, setDisplay] = useState(currentValue);
+  console.log("display", display);
+
+  useEffect(() => {
+    if (typeof props.value === "object") {
+      setDisplayMax(false);
+      
+      const decimalCorrectedAmount = parseFloat(ethers.utils.formatUnits(props.value));
+
+      if (mode !== "USD") {
+        props.onChange(decimalCorrectedAmount);
+        setDisplay(decimalCorrectedAmount);
+      }
+      else if (typeof props.price === "number") {
+        props.onChange(decimalCorrectedAmount);
+        setDisplay((decimalCorrectedAmount * props.price).toFixed(2));
+      } 
+    }
+  }, [props.value, props.price]);
 
   const balance = useBalance(props.provider, props.address, 1000);
   let floatBalance = parseFloat("0.00");
@@ -57,6 +79,8 @@ export default function EtherInput(props) {
     if (floatBalance < 0) {
       floatBalance = 0;
     }
+    console.log("xxx etherBalance", etherBalance);
+    console.log("xxx floatBalance", floatBalance);
   }
 
   let displayBalance = floatBalance.toFixed(4);

--- a/packages/react-app/src/components/GenericModal.jsx
+++ b/packages/react-app/src/components/GenericModal.jsx
@@ -1,54 +1,20 @@
-import { Button } from "antd";
 import React from "react";
-import { createPortal, render } from "react-dom";
+import { Modal } from "antd";
 
-const showModal = (error, isError) => {
-  console.error(error);
+const showModal = (error) => {
+  const popUp = () => {
+    const title = "Coudn't parse the payment link/QR code!";
 
-  const closeModal = () => {
-    const modalElement = document.getElementById("errorModal");
-    document.body.removeChild(modalElement);
+    Modal.confirm({
+      width: "90%",
+      title: title,
+      maskClosable: true,
+      cancelButtonProps: { style: { display: "none" } },
+      content: <div>{error}</div>,
+    });
   };
 
-  return render(
-    createPortal(
-      <div
-        style={{
-          padding: "4rem",
-          textAlign: "center",
-          display: "flex",
-          gap: "2rem",
-          flexDirection: "column",
-          height: "auto",
-          width: "80vw",
-          position: "absolute",
-          zIndex: "999",
-          top: "50%",
-          left: "50%",
-          backgroundColor: "#fff",
-          border: `4px solid ${isError ? "#ffbdbd" : "#ffefbd"}`,
-          borderRadius: "4px",
-          transform: "translate(-50%, -50%)",
-        }}
-        id="errorModal"
-      >
-        <span onClick={closeModal} style={{ padding: "1rem", cursor: "pointer" }} className="ant-modal-close">
-          X
-        </span>
-        <span>Something went wrong:</span>
-        {error}
-        <Button
-          onClick={closeModal}
-          style={{ cursor: "pointer", color: isError ? "red" : "yellow" }}
-          className="ant-btn-default"
-        >
-          OK
-        </Button>
-      </div>,
-      document.body,
-    ),
-    document.createElement("div"),
-  );
+  return popUp();
 };
 
 export default showModal;

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -45,7 +45,9 @@ export default function QRPunkBlockie({
         try {
           const decimals = selectedErc20Token ? selectedErc20Token.decimals : 18;
 
-          amountString = ethers.utils.parseUnits(amount.toFixed(decimals).toString(), decimals).toString();
+          amountString = ethers.utils
+            .parseUnits(typeof amount === "string" ? amount : amount.toFixed(decimals).toString(), decimals)
+            .toString();
         } catch (error) {
           console.error("Couldn't parse amount", amount, error);
         }

--- a/packages/react-app/src/components/QRPunkBlockie.jsx
+++ b/packages/react-app/src/components/QRPunkBlockie.jsx
@@ -60,11 +60,10 @@ export default function QRPunkBlockie({
       }
 
       const eip681 = build(eip681Data);
-      console.log("eip681", eip681);
 
       displayValue = eip681;
 
-      paymentLink = "http://localhost:3000/" + displayValue;
+      paymentLink = window.location.href + displayValue;
     } catch (error) {
       console.error("Couldn't create EIP-681 QR value", error);
     }

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -725,4 +725,7 @@ export const ERROR_MESSAGES = {
     NOT_SUPPORTED: "ChainId is not supported",
     NOT_PROVIDED: "ChainId is not provided",
   },
+  TOKEN_ERROR: {
+    NOT_SUPPORTED: "Token is not supported",
+  },
 };

--- a/packages/react-app/src/helpers/EIP618Helper.js
+++ b/packages/react-app/src/helpers/EIP618Helper.js
@@ -38,9 +38,15 @@ export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, 
   if (functionName == "transfer" && tokenAddress) {
     localStorage.setItem("switchToTokenAddress", tokenAddress);
     toAddress = eip681Object?.parameters?.address;
+    amount = eip681Object?.parameters?.uint256;
   } else {
     localStorage.setItem("switchToEth", true);
     toAddress = eip681Object?.target_address;
+    amount = eip681Object?.parameters?.value;
+  }
+
+  if (amount) {
+    localStorage.setItem("amount", amount);
   }
 
   if (toAddress) {

--- a/packages/react-app/src/helpers/EIP618Helper.js
+++ b/packages/react-app/src/helpers/EIP618Helper.js
@@ -4,45 +4,51 @@ import { parse } from "eth-url-parser";
 
 const { CHAIN_ERROR } = ERROR_MESSAGES;
 
-export const handleNetworkByQR = (chainId, networkSettingsHelper, setTargetNetwork) => {
+const handleNetworkChange = (chainId, networkSettingsHelper, setTargetNetwork) => {
   if (chainId) {
     const incomingNetwork = Object.values(NETWORKS).find(network => network.chainId === parseInt(chainId));
+
     if (incomingNetwork) {
-      console.log("incoming network:", incomingNetwork);
-      networkSettingsHelper.updateSelectedName(incomingNetwork.name);
-      setTargetNetwork(networkSettingsHelper.getSelectedItem(true));
+      const currentNetwork = networkSettingsHelper.getSelectedItem();
+
+      if (currentNetwork.chainId !== incomingNetwork.chainId) {
+        networkSettingsHelper.updateSelectedName(incomingNetwork.name);
+        setTargetNetwork(networkSettingsHelper.getSelectedItem(true));
+      }
     } else {
-      // error screen that chainId is not supported
       showModal(CHAIN_ERROR.NOT_SUPPORTED, true);
     }
   } else {
-    // warning screen that chainId is not provided
     showModal(CHAIN_ERROR.NOT_PROVIDED, false);
   }
 };
 
 export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, setToAddress) => {
   const eip681Object = parse(eip681URL);
-  console.log("eip681Object", eip681Object);
 
   const chainId = eip681Object.chain_id;
 
-  handleNetworkByQR(chainId, networkSettingsHelper, setTargetNetwork);
+  handleNetworkChange(chainId, networkSettingsHelper, setTargetNetwork);
 
   const functionName = eip681Object.function_name;
-  const tokenAddress = eip681Object?.target_address;
 
-  let toAddress;
   let amount;
+  let toAddress;
+  
+  if (functionName == "transfer") {
+    const tokenAddress = eip681Object.target_address;
 
-  if (functionName == "transfer" && tokenAddress) {
-    localStorage.setItem("switchToTokenAddress", tokenAddress);
-    toAddress = eip681Object?.parameters?.address;
-    amount = eip681Object?.parameters?.uint256;
+    if (tokenAddress) {
+      localStorage.setItem("switchToTokenAddress", tokenAddress);
+      amount = eip681Object.parameters?.uint256;
+    }
+    
+    toAddress = eip681Object.parameters?.address;
   } else {
     localStorage.setItem("switchToEth", true);
-    toAddress = eip681Object?.target_address;
-    amount = eip681Object?.parameters?.value;
+
+    amount = eip681Object.parameters?.value;
+    toAddress = eip681Object.target_address;
   }
 
   if (amount) {

--- a/packages/react-app/src/helpers/EIP618Helper.js
+++ b/packages/react-app/src/helpers/EIP618Helper.js
@@ -1,6 +1,7 @@
 import showModal from "../components/GenericModal";
 import { NETWORKS, ERROR_MESSAGES } from "../constants";
 import { parse } from "eth-url-parser";
+import BigNumber from 'bignumber.js';
 
 const { CHAIN_ERROR } = ERROR_MESSAGES;
 
@@ -52,7 +53,7 @@ export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, 
   }
 
   if (amount) {
-    localStorage.setItem("amount", amount);
+    localStorage.setItem("amount", new BigNumber(amount).toFixed());
   }
 
   if (toAddress) {

--- a/packages/react-app/src/helpers/EIP618Helper.js
+++ b/packages/react-app/src/helpers/EIP618Helper.js
@@ -17,10 +17,10 @@ const handleNetworkChange = (chainId, networkSettingsHelper, setTargetNetwork) =
         setTargetNetwork(networkSettingsHelper.getSelectedItem(true));
       }
     } else {
-      showModal(CHAIN_ERROR.NOT_SUPPORTED, true);
+      showModal(CHAIN_ERROR.NOT_SUPPORTED + " : " + chainId);
     }
   } else {
-    showModal(CHAIN_ERROR.NOT_PROVIDED, false);
+    showModal(CHAIN_ERROR.NOT_PROVIDED);
   }
 };
 

--- a/packages/react-app/src/helpers/EIP618Helper.js
+++ b/packages/react-app/src/helpers/EIP618Helper.js
@@ -24,7 +24,7 @@ const handleNetworkChange = (chainId, networkSettingsHelper, setTargetNetwork) =
   }
 };
 
-export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, setToAddress) => {
+export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, setToAddress, setAmount) => {
   const eip681Object = parse(eip681URL);
 
   const chainId = eip681Object.chain_id;
@@ -54,6 +54,9 @@ export const parseEIP618 = (eip681URL, networkSettingsHelper, setTargetNetwork, 
 
   if (amount) {
     localStorage.setItem("amount", new BigNumber(amount).toFixed());
+  }
+  else {
+    setAmount("");
   }
 
   if (toAddress) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5733,6 +5733,11 @@ bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
   integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
This PR adds a new **Send/Receive** switch.
![Screenshot 2024-06-14 at 15 18 33](https://github.com/scaffold-eth/punk-wallet/assets/1397179/f2eecadc-2950-432b-a2dc-5aaad2d26d20)


In Receive mode, an **EIP-681** QR code is generated, with the chain/token/address/amount info.
Clicking on the QR copies the payment link, which can be sent over to a friend, e.g. requesting 10USD on polygon.

Scanning the QR or pasting the payment link switches to the requested chain/token and populates the toAddress and the amount.

https://github.com/scaffold-eth/punk-wallet/assets/1397179/5794e621-8ba3-4a18-8cf9-31450d42f864

As the QR codes use EIP-681, we can use other wallets like MetaMask mobile to scan/generate payments.

This is an example for scanning a MetaMask payment QR for 0.1 OP token.

https://github.com/scaffold-eth/punk-wallet/assets/1397179/ab332468-bad8-4844-977a-4d94a0eccee2

Demo Site:
https://erratic-trick.surge.sh/

