### PR TITLE
RPC usage

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -430,9 +430,6 @@ function App(props) {
     }
   }, [injectedProvider, localProvider, address]);
 
-  // Just plug in different 🛰 providers to get your balance on different chains:
-  const yourMainnetBalance = useBalance(mainnetProvider, address);
-
   //
   // 🧫 DEBUG 👨🏻‍🔬
   //

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -156,6 +156,7 @@ function App(props) {
 
   const [targetNetwork, setTargetNetwork] = useState(() => networkSettingsHelper.getSelectedItem(true));
 
+  const [mainnetProvider] = useState(() => new StaticJsonRpcProvider(NETWORKS.ethereum.rpcUrl));
   const [localProvider, setLocalProvider] = useState(() => new StaticJsonRpcProvider(targetNetwork.rpcUrl));
   useEffect(() => {
     setLocalProvider(prevProvider =>
@@ -202,8 +203,6 @@ function App(props) {
 
     localStorage.removeItem("switchToEth");
   }
-
-  const mainnetProvider = new StaticJsonRpcProvider(NETWORKS.ethereum.rpcUrl);
 
   const [injectedProvider, setInjectedProvider] = useState();
 


### PR DESCRIPTION
Moving the _mainnetProvider_ to state reduces RPC usage quite significantly.

This image shows the usage with this fix at the beginning, then I switched back to the master branch.


<img width="1174" alt="Screenshot 2024-10-03 at 21 51 15" src="https://github.com/user-attachments/assets/bc333a76-5c45-41d7-9970-6568695b0a67">
