### PR TITLE
Enhance SelectorWithSettings component: add search functionality and use dynamically height

### DIFF
--- a/packages/react-app/src/components/SelectorWithSettings.jsx
+++ b/packages/react-app/src/components/SelectorWithSettings.jsx
@@ -3,61 +3,65 @@ import React, { useEffect, useState } from "react";
 import { Select } from "antd";
 import { SettingOutlined } from "@ant-design/icons";
 
-export default function SelectorWithSettings({settingsHelper, itemCoreDisplay, settingsModalOpen, onChange, optionStyle}) {
-    const selectedItem = settingsHelper.getSelectedItem();
-    const selectedItemName = selectedItem ? selectedItem.name : settingsHelper.items[0].name;
-
-    const [currentValue, setCurrentValue] = useState(selectedItemName);
-
-    useEffect(() => {
-        // This is only needed once, after migrating an old storage key
-        if (selectedItem && (selectedItem.name != currentValue)) {
-            setCurrentValue(selectedItem.name);
-        }
-    }, [selectedItem]);
-    
-    const options = settingsHelper.sortedItems.map(
-        (item) => option(item, itemCoreDisplay, optionStyle)
-    );
-
-    options.push(
-        option({name:SETTINGS_NAME}, settingsOption, {fontSize:32})
-    );
-
-    return (
-        <div>
-            <Select
-                size="large"
-                defaultValue={currentValue}
-                style={{ width: 170, fontSize: 24 }}
-                listHeight={1024}
-                onChange={(value) => {
-                    if (value == SETTINGS_NAME) {
-                        settingsModalOpen(true);
-                    }
-                    else {
-                        setCurrentValue(value);
-                        settingsHelper.updateSelectedName(value);
-                        onChange && onChange(value);
-                    }
-                }}
-                value={currentValue}
-            >
-                {options}
-            </Select>
-        </div>
-    );
-}
-
 const option = (item, itemCoreDisplay, style) => (
-    <Select.Option key={item.name} value={item.name} style={{lineHeight:2, fontSize:24, ...style}}>
-        {itemCoreDisplay(item)}
-    </Select.Option>
+  <Select.Option key={item.name} value={item.name} style={{ lineHeight: 2, fontSize: 24, ...style }}>
+    {itemCoreDisplay(item)}
+  </Select.Option>
 );
 
 const SETTINGS_NAME = "SettingsName";
 const settingsOption = () => (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center"}}>
-        <SettingOutlined />
-    </div>
+  <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+    <SettingOutlined />
+  </div>
 );
+
+export default function SelectorWithSettings({
+  settingsHelper,
+  itemCoreDisplay,
+  settingsModalOpen,
+  onChange,
+  optionStyle,
+}) {
+  const selectedItem = settingsHelper.getSelectedItem();
+  const selectedItemName = selectedItem ? selectedItem.name : settingsHelper.items[0].name;
+
+  const [currentValue, setCurrentValue] = useState(selectedItemName);
+
+  useEffect(() => {
+    // This is only needed once, after migrating an old storage key
+    if (selectedItem && selectedItem.name != currentValue) {
+      setCurrentValue(selectedItem.name);
+    }
+  }, [selectedItem]);
+
+  const options = settingsHelper.sortedItems.map(item => option(item, itemCoreDisplay, optionStyle));
+
+  options.push(option({ name: SETTINGS_NAME }, settingsOption, { fontSize: 32 }));
+
+  const listHeight = window.innerHeight * 0.6;
+
+  return (
+    <div>
+      <Select
+        size="large"
+        defaultValue={currentValue}
+        style={{ width: 170, fontSize: 24 }}
+        listHeight={listHeight}
+        showSearch
+        onChange={value => {
+          if (value == SETTINGS_NAME) {
+            settingsModalOpen(true);
+          } else {
+            setCurrentValue(value);
+            settingsHelper.updateSelectedName(value);
+            onChange && onChange(value);
+          }
+        }}
+        value={currentValue}
+      >
+        {options}
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
### Why
Current setting component takes fix 1024 height and not searchable. This makes it harder to choose a network when screen height is small.

### What
1. Instead of using default 1024 height, use 60% of available height. This reduction in height will add scroll bar to select drop down.
2. Add an search property to select such that user can type the network to select it quickly.
3. Moved function and variable declaration to top of component to remove es lint errors.

Before | After
![image](https://github.com/user-attachments/assets/6896d5a0-b570-4a7f-9cd1-ab7d7804fad5) | 
![image](https://github.com/user-attachments/assets/37fc6398-9e4c-4001-86e2-02bb76fdebcc)

Search
![image](https://github.com/user-attachments/assets/5d1e1053-3b7d-466f-8242-f98a338785dd)

