### PR TITLE
Fix "max fee per gas less than block base fee:", Arbitrum refunds the gas

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1112,8 +1112,9 @@ function App(props) {
                   }
 
                   if (networkName == "arbitrum") {
-                    //txConfig.gasLimit = 21000;
-                    //ask rpc for gas price
+                    // Fix "max fee per gas less than block base fee:"
+                    // Arbitrum refunds the gas
+                    txConfig.gasPrice = gasPrice.mul(2);
                   } else if (networkName == "optimism") {
                     //ask rpc for gas price
                   } else if (networkName == "gnosis") {


### PR DESCRIPTION
On **Arbitrum** I run into this error from time to time.

<img width="1503" alt="Screenshot 2025-06-30 at 17 24 51" src="https://github.com/user-attachments/assets/debbb449-8cc7-4385-804f-aca28bb2cf5a" />

**Since Arbitrum refunds the gas, a quick fix can be to double the gasPrice.**

![Screenshot 2025-07-01 at 13 09 57](https://github.com/user-attachments/assets/a277faa8-3330-4ecb-99e4-31869e60b080)

