### PR TITLE
fix: personal_sign should sign raw bytes, not UTF-8-decode the payload

### DIFF
--- a/packages/react-app/src/helpers/WalletConnectV2Helper.js
+++ b/packages/react-app/src/helpers/WalletConnectV2Helper.js
@@ -195,11 +195,18 @@ export const signTransaction = txParams => {
 export const signMessage = message => {
   const ethersWallet = createEthersWallet();
 
-  if (ethers.utils.isHexString(message)) {
-    message = ethers.utils.toUtf8String(message);
-  }
+  // For `personal_sign`, a hex-string param is the *raw bytes* to sign
+  // (EIP-191) — NOT UTF-8 text. Arrayify and sign the bytes directly so
+  // `signMessage` applies the "\x19Ethereum Signed Message:\n<len>" prefix
+  // over those exact bytes. The old `toUtf8String` path threw
+  // "invalid codepoint / unexpected continuation byte" on any payload that
+  // wasn't valid UTF-8 (e.g. a 32-byte hash from a Safe/multisig approval
+  // or a login challenge); for payloads that *were* valid UTF-8 it just
+  // round-tripped to the same bytes anyway, so this is strictly safer.
+  // A non-hex param stays a literal string and is signed as UTF-8.
+  const data = ethers.utils.isHexString(message) ? ethers.utils.arrayify(message) : message;
 
-  return ethersWallet.signMessage(message);
+  return ethersWallet.signMessage(data);
 };
 
 export const sendWalletConnectTx = async (userProvider, payload, chainId) => {


### PR DESCRIPTION
Connecting Punk Wallet as a WalletConnect signer to a dapp that asks it to `personal_sign` a **binary** payload (e.g. a 32-byte hash) currently throws and never produces a signature:

```
Error: invalid codepoint at offset 0; unexpected continuation byte
  (argument="bytes", value=Uint8Array(0x838b…), code=INVALID_ARGUMENT, version=strings/5.7.0)
  at toUtf8String (utf8.ts)
  at signMessage (WalletConnectV2Helper.js:199)
```

### Cause

`signMessage` runs any hex payload through `ethers.utils.toUtf8String` before signing:

```js
if (ethers.utils.isHexString(message)) {
  message = ethers.utils.toUtf8String(message);
}
return ethersWallet.signMessage(message);
```

For `personal_sign`, a hex param is the **raw bytes to sign** per EIP-191 — not UTF-8 text. Any payload that isn’t valid UTF-8 (a Safe/multisig approval hash, a login challenge, etc.) makes `toUtf8String` throw, and the request dies in `WalletConnectTransactionPopUp` before a signature is ever returned.

### Fix

Arrayify hex payloads and sign the bytes directly, so `signMessage` applies the `\x19Ethereum Signed Message:\n<len>` prefix over those exact bytes:

```js
const data = ethers.utils.isHexString(message) ? ethers.utils.arrayify(message) : message;
return ethersWallet.signMessage(data);
```

### No regression

- Payloads that were already valid UTF-8 hex round-trip to the same bytes, so they produce the identical signature — this is a strict superset of the old behaviour.
- Non-hex params stay literal strings and are signed as UTF-8 (Monerium link/order messages, etc. — unchanged).
- `eth_sign` is unaffected (it goes through `userProvider.send`, not this function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)